### PR TITLE
Add time scale control to dev panel

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -225,6 +225,7 @@ export default class MainScene extends Phaser.Scene {
         // --- DevTools integration ---
         // Apply current hitbox flag right away (responds to future toggles too)
         DevTools.applyHitboxFlag(this);
+        DevTools.applyTimeScale(this);
 
         // Listen for dev spawn events
         this.game.events.on('dev:spawn-zombie', ({ type, pos }) =>

--- a/scenes/PauseScene.js
+++ b/scenes/PauseScene.js
@@ -7,6 +7,8 @@
 //   [ Coming Soon ] [ Coming Soon ] (two small buttons, second row, placeholders)
 //   [ Return to Menu ] (wide button at bottom; currently non-functional)
 
+import DevTools from '../systems/DevTools.js';
+
 export default class PauseScene extends Phaser.Scene {
   constructor() {
     super('PauseScene');
@@ -26,6 +28,8 @@ export default class PauseScene extends Phaser.Scene {
     if (this.scene.isActive('MainScene')) {
       this.scene.pause('MainScene');
     }
+
+    DevTools.applyTimeScale(this);
 
     const { width: W, height: H } = this.scale;
 

--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -2,6 +2,7 @@
 import InventoryModel from '../systems/inventoryModel.js';
 import { INVENTORY_CONFIG } from '../data/inventoryConfig.js';
 import { ITEM_DB } from '../data/itemDatabase.js';
+import DevTools from '../systems/DevTools.js';
 
 export default class UIScene extends Phaser.Scene {
     constructor() {
@@ -30,6 +31,7 @@ export default class UIScene extends Phaser.Scene {
         // Inventory model (logic)
         // -------------------------
         this.inventory = new InventoryModel(this.events);
+        DevTools.applyTimeScale(this);
 
         // -------------------------
         // Basic HUD


### PR DESCRIPTION
Summary:
- add Control section to Dev UI with 0x-10x game speed multiplier
- allow DevTools to apply time scale across scenes

Technical Approach:
- DevTools: add timeScale flag, setTimeScale/applyTimeScale helpers
- DevUIScene: new Control section with editable time scale, initialization, commit/bump helpers
- MainScene/UIScene/PauseScene: apply current time scale on create

Performance:
- time scale applied only when changed; avoids per-frame allocations

Risks & Rollback:
- extreme time scales may expose latent timing bugs
- rollback by resetting time scale to 1 or reverting commit

QA Steps:
- open Dev Mode via pause menu
- set Time Scale to 0x and verify world freezes
- set Time Scale to 10x and verify world runs 10x faster
- reset Time Scale to 1x


------
https://chatgpt.com/codex/tasks/task_e_68aa3117ad4c8322aa2ec1f0c553648d