### PR TITLE
chore: add node-based test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Zombie Survival
+
+Phaser 3 top-down zombie survival game.
+
+## Testing
+
+Run the test suite:
+
+```
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "zombiesurvival",
+    "version": "1.0.0",
+    "description": "Phaser 3 top-down zombie survival game.",
+    "main": "bootstrap.js",
+    "type": "module",
+    "scripts": {
+        "test": "node --test"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC"
+}

--- a/test/systems/DevTools.test.js
+++ b/test/systems/DevTools.test.js
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import DevTools from '../../systems/DevTools.js';
+
+test('setMeleeSliceBatch clamps to 1 or 2', () => {
+    DevTools.setMeleeSliceBatch(2);
+    assert.equal(DevTools.flags.meleeSliceBatch, 2);
+    DevTools.setMeleeSliceBatch(0);
+    assert.equal(DevTools.flags.meleeSliceBatch, 1);
+});


### PR DESCRIPTION
### Summary
- add `package.json` with Node's built-in test runner
- verify `DevTools.setMeleeSliceBatch` with an example spec
- document `npm test` usage

### Technical Approach
- `package.json` adds test script (`node --test`)
- `test/systems/DevTools.test.js` covers simple flag logic
- `README.md` notes how to run tests
- `.gitignore` excludes `node_modules`

### Performance
- test code runs outside gameplay; no per-frame allocations

### Risks & Rollback
- minimal; revert commit to remove test setup

### QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3a71818883229a95065ac05b5a28