### PR TITLE
fix: rename flags to cheats and stabilize time control

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -65,7 +65,7 @@ export default class DevUIScene extends Phaser.Scene {
             count: startCount,
         };
 
-        this._time = { scale: String(DevTools.flags.timeScale || 1) };
+        this._time = { scale: String(DevTools.cheats.timeScale || 1) };
     }
 
     create() {
@@ -105,11 +105,11 @@ export default class DevUIScene extends Phaser.Scene {
         this.content = this.add.container(0, 54).setDepth(1);
 
         let y = 0;
-        y = this._sectionTitle('Flags', y);
-        y = this._rowToggle('Show Hitboxes', () => DevTools.flags.showHitboxes, v => DevTools.setShowHitboxes(v), y);
-        y = this._rowToggle('Invisible',      () => DevTools.flags.invisible,    v => DevTools.flags.invisible = v, y);
-        y = this._rowToggle('Infinite Health',() => DevTools.flags.invincible,   v => {
-            DevTools.flags.invincible = v;
+        y = this._sectionTitle('Cheats', y);
+        y = this._rowToggle('Show Hitboxes', () => DevTools.cheats.showHitboxes, v => DevTools.setShowHitboxes(v), y);
+        y = this._rowToggle('Invisible',      () => DevTools.cheats.invisible,    v => DevTools.cheats.invisible = v, y);
+        y = this._rowToggle('Infinite Health',() => DevTools.cheats.invincible,   v => {
+            DevTools.cheats.invincible = v;
             if (v) {
                 const mainScene = this.scene.get('MainScene');
                 if (mainScene) {
@@ -119,8 +119,8 @@ export default class DevUIScene extends Phaser.Scene {
                 }
             }
         }, y);
-        y = this._rowToggle('Infinite Stamina',() => DevTools.flags.noStamina,    v => {
-            DevTools.flags.noStamina = v;
+        y = this._rowToggle('Infinite Stamina',() => DevTools.cheats.noStamina,    v => {
+            DevTools.cheats.noStamina = v;
             if (v) {
                 const mainScene = this.scene.get('MainScene');
                 if (mainScene) {
@@ -129,8 +129,8 @@ export default class DevUIScene extends Phaser.Scene {
                 }
             }
         }, y);
-        y = this._rowToggle('No Cooldown',     () => DevTools.flags.noCooldown,   v => DevTools.flags.noCooldown = v, y);
-        y = this._rowToggle('Infinite Ammo',   () => DevTools.flags.noAmmo,       v => DevTools.flags.noAmmo = v, y);
+        y = this._rowToggle('No Cooldown',     () => DevTools.cheats.noCooldown,   v => DevTools.cheats.noCooldown = v, y);
+        y = this._rowToggle('Infinite Ammo',   () => DevTools.cheats.noAmmo,       v => DevTools.cheats.noAmmo = v, y);
 
         y = this._sectionTitle('Spawners', y);
         y = this._enemySpawnerRow(y);
@@ -153,7 +153,7 @@ export default class DevUIScene extends Phaser.Scene {
         });
 
         // Make sure hitbox render and time scale react immediately
-        DevTools.applyHitboxFlag(this.scene.get('MainScene'));
+        DevTools.applyHitboxCheat(this.scene.get('MainScene'));
         DevTools.applyTimeScale(this);
     }
 
@@ -212,9 +212,9 @@ export default class DevUIScene extends Phaser.Scene {
         const label = this.add.text(UI.pad + 6, y + 12, 'Time Scale', UI.font).setDepth(2);
 
         const minusX = this.scale.width - 220;
-        const minus = this._makeButton(minusX, y + 9, 26, 26, '–', () => this._bumpTimeScale(-1), 2);
+        const minus = this._makeButton(minusX, y + 9, 26, 26, '–', () => this._bumpTimeScale(-0.1), 2);
         this._timeText = this._makeEditableNumber(minusX + 30, y + 9, 60, 26, () => this._time.scale, (s) => { this._time.scale = s; this._commitTimeScale(); });
-        const plus = this._makeButton(minusX + 94, y + 9, 26, 26, '+', () => this._bumpTimeScale(1), 2);
+        const plus = this._makeButton(minusX + 94, y + 9, 26, 26, '+', () => this._bumpTimeScale(0.1), 2);
 
         this.content.add([card, label, minus, this._timeText.box, plus]);
         return y + UI.rowH;
@@ -735,17 +735,22 @@ export default class DevUIScene extends Phaser.Scene {
         if (raw === '') raw = '0';
         let val = parseFloat(raw);
         if (!Number.isFinite(val)) val = 0;
+        val = Math.round(val * 10) / 10;
         val = Phaser.Math.Clamp(val, 0, 10);
-        this._time.scale = String(val);
-        this._timeText?.set?.(this._time.scale);
+        this._time.scale = val.toFixed(1).replace(/\.0$/, '');
+        if (this._timeText?.txt) this._timeText.txt.setText(this._time.scale);
+        this._timeText?.stopEdit?.(false);
         DevTools.setTimeScale(val, this.game);
     }
 
+
     _bumpTimeScale(delta) {
         let val = parseFloat(this._time.scale) || 0;
-        val = Phaser.Math.Clamp(val + delta, 0, 10);
-        this._time.scale = String(val);
-        this._timeText?.set?.(this._time.scale);
+        val = Math.round((val + delta) * 10) / 10;
+        val = Phaser.Math.Clamp(val, 0, 10);
+        this._time.scale = val.toFixed(1).replace(/\.0$/, '');
+        if (this._timeText?.txt) this._timeText.txt.setText(this._time.scale);
+        this._timeText?.stopEdit?.(false);
         DevTools.setTimeScale(val, this.game);
     }
 

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -223,8 +223,8 @@ export default class MainScene extends Phaser.Scene {
             .setAlpha(0);
 
         // --- DevTools integration ---
-        // Apply current hitbox flag right away (responds to future toggles too)
-        DevTools.applyHitboxFlag(this);
+        // Apply current hitbox cheat right away (responds to future toggles too)
+        DevTools.applyHitboxCheat(this);
         DevTools.applyTimeScale(this);
 
         // Listen for dev spawn events

--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -6,9 +6,9 @@
 
 const DevTools = {
     // ─────────────────────────────────────────────────────────────
-    // FLAGS (wired from Dev UI)
+    // CHEATS (wired from Dev UI)
     // ─────────────────────────────────────────────────────────────
-    flags: {
+    cheats: {
         showHitboxes: false,
         invisible:    false,
         invincible:   false,
@@ -37,12 +37,12 @@ const DevTools = {
     _lastScene: null,
 
     // Public helpers used by scenes
-    isPlayerInvisible() { return !!this.flags.invisible; },
-    shouldConsumeAmmo() { return !this.flags.noAmmo; },
-    shouldConsumeStamina() { return !this.flags.noStamina; },
+    isPlayerInvisible() { return !!this.cheats.invisible; },
+    shouldConsumeAmmo() { return !this.cheats.noAmmo; },
+    shouldConsumeStamina() { return !this.cheats.noStamina; },
 
     // gate for player damage (invincible toggle)
-    shouldBlockPlayerDamage() { return !!this.flags.invincible; },
+    shouldBlockPlayerDamage() { return !!this.cheats.invincible; },
 
     // simple persistence for Dev UI spawner (lives across DevUI open/close)
     _getEnemySpawnPrefs() { return this._enemySpawnPrefs || null; },
@@ -58,16 +58,16 @@ const DevTools = {
 
     // reset dev toggles to defaults (used on death)
     resetToDefaults(scene = null) {
-        this.flags.showHitboxes   = false;
-        this.flags.invincible     = false;
-        this.flags.invisible      = false;
-        this.flags.noAmmo         = false;
-        this.flags.noStamina      = false;
-        this.flags.noCooldown     = false;
-        this.flags.meleeSliceBatch = 1;
-        this.flags.timeScale       = 1;
+        this.cheats.showHitboxes   = false;
+        this.cheats.invincible     = false;
+        this.cheats.invisible      = false;
+        this.cheats.noAmmo         = false;
+        this.cheats.noStamina      = false;
+        this.cheats.noCooldown     = false;
+        this.cheats.meleeSliceBatch = 1;
+        this.cheats.timeScale       = 1;
         // Re-apply hitbox visibility immediately (hides layers if they were on)
-        try { this.applyHitboxFlag(scene || this._lastScene); } catch {}
+        try { this.applyHitboxCheat(scene || this._lastScene); } catch {}
         // Reset global time scale
         try { this.setTimeScale(1, (scene || this._lastScene)?.game); } catch {}
     },
@@ -75,7 +75,7 @@ const DevTools = {
     // Public API: change between 1 or 2 slices per tick at runtime
     setMeleeSliceBatch(n = 1) {
         const v = (n | 0);
-        this.flags.meleeSliceBatch = (v <= 1) ? 1 : 2;
+        this.cheats.meleeSliceBatch = (v <= 1) ? 1 : 2;
     },
 
     // Set global time scale (0..10) and apply to all scenes
@@ -84,7 +84,7 @@ const DevTools = {
         if (!Number.isFinite(v)) v = 1;
         if (v < 0) v = 0;
         if (v > 10) v = 10;
-        this.flags.timeScale = v;
+        this.cheats.timeScale = v;
 
         const mgr = game?.scene;
         if (mgr && Array.isArray(mgr.scenes)) {
@@ -99,7 +99,7 @@ const DevTools = {
     },
 
     applyTimeScale(scene) {
-        const v = this.flags.timeScale;
+        const v = this.cheats.timeScale;
         if (!scene) return;
         try {
             if (scene.time) scene.time.timeScale = v;
@@ -109,14 +109,14 @@ const DevTools = {
 
     // Toggle entry point used by Dev UI
     setShowHitboxes(value, scene) {
-        this.flags.showHitboxes = !!value;
+        this.cheats.showHitboxes = !!value;
         if (scene) this._lastScene = scene;
-        if (this._lastScene) this.applyHitboxFlag(this._lastScene);
+        if (this._lastScene) this.applyHitboxCheat(this._lastScene);
     },
 
-    applyHitboxFlag(scene) {
+    applyHitboxCheat(scene) {
         this._ensureLayers(scene);
-        const vis = !!this.flags.showHitboxes;
+        const vis = !!this.cheats.showHitboxes;
         this._gfx.enemies.setVisible(vis);
         this._gfx.attacks.setVisible(vis);
         this._gfx.resources.setVisible(vis);
@@ -136,7 +136,7 @@ const DevTools = {
 
     // Call this once per frame from MainScene.update()
     tickHitboxDebug(scene) {
-        if (!this.flags.showHitboxes) return;
+        if (!this.cheats.showHitboxes) return;
         this._ensureLayers(scene);
 
         const now = scene.time.now | 0;
@@ -233,7 +233,7 @@ const DevTools = {
         const mh = scene.meleeHits;
         if (mh && mh.children?.iterate) {
             const N     = Math.max(1, (this._MELEE_SUBDIV | 0));                 // total slices across cone
-            const batch = Math.max(1, (this.flags.meleeSliceBatch | 0)) > 1 ? 2 : 1; // 1 or 2
+            const batch = Math.max(1, (this.cheats.meleeSliceBatch | 0)) > 1 ? 2 : 1; // 1 or 2
             const now   = scene.time.now | 0;
 
             mh.children.iterate((hit) => {

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -259,7 +259,7 @@ export default function createCombatSystem(scene) {
             lowStamina && typeof st.lowCooldownMultiplier === 'number'
                 ? Math.floor(baseCd * st.lowCooldownMultiplier)
                 : baseCd;
-        if (!DevTools.flags.noCooldown && cdMs > 0) {
+        if (!DevTools.cheats.noCooldown && cdMs > 0) {
             scene._nextRangedReadyTime = scene.time.now + cdMs;
             scene.uiScene?.events?.emit('weapon:cooldownStart', {
                 itemId: equipped.id,
@@ -400,7 +400,7 @@ export default function createCombatSystem(scene) {
                     scene.batSprite = null;
                 }
                 if (
-                    !DevTools.flags.noCooldown &&
+                    !DevTools.cheats.noCooldown &&
                     scene._nextSwingCooldownMs > 0
                 ) {
                     scene.uiScene?.events?.emit('weapon:cooldownStart', {

--- a/systems/inputSystem.js
+++ b/systems/inputSystem.js
@@ -21,7 +21,7 @@ export default function createInputSystem(scene) {
             const baseCd = wpn?.swingCooldownMs ?? 80;
             const effectiveCd = scene._nextSwingCooldownMs ?? baseCd;
             const lastEnd = scene._lastSwingEndTime || 0;
-            if (!DevTools.flags.noCooldown && now - lastEnd < effectiveCd)
+            if (!DevTools.cheats.noCooldown && now - lastEnd < effectiveCd)
                 return;
 
             if (wpn.canCharge === true) {
@@ -44,7 +44,7 @@ export default function createInputSystem(scene) {
             const now = scene.time.now;
             const fireCd = wpn?.fireCooldownMs ?? 0;
             if (
-                !DevTools.flags.noCooldown &&
+                !DevTools.cheats.noCooldown &&
                 fireCd > 0 &&
                 now < (scene._nextRangedReadyTime || 0)
             )


### PR DESCRIPTION
## Summary
- rename dev flags to cheats and update UI labels
- adjust dev time scale step to 0.1 and close editor after change
- rename hitbox helper to `applyHitboxCheat`

## Technical Approach
- replace `DevTools.flags` with `cheats` across systems and scenes
- round time scale to one decimal, stop editing, and use ±0.1 buttons
- update references and comments to new helper name

## Performance
- only basic math; no additional allocations in `update()`

## Risks & Rollback
- typo in cheat renames could break DevTools toggles; revert commit if issues arise

## QA Steps
- `npm test` (fails: package.json missing)
- open Dev UI and toggle cheats
- use +/- buttons to adjust time scale by 0.1
- edit time scale value and click away; editor should close


------
https://chatgpt.com/codex/tasks/task_e_68aa3b30e18c8322b5cd9bf0f477f3da