### PR TITLE
fix: correct time scale direction and allow decimal input

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -480,7 +480,16 @@ export default class DevUIScene extends Phaser.Scene {
                 return;
             }
             if (/^[0-9]$/.test(ev.key)) {
-                if (t.text.length < 3) t.setText(t.text + ev.key);
+                const max = t.text.includes('.') ? 4 : 3;
+                if (t.text.length < max) t.setText(t.text + ev.key);
+                return;
+            }
+            if (
+                ev.key === '.' &&
+                this._editing === this._timeText &&
+                !t.text.includes('.')
+            ) {
+                if (t.text.length < 4) t.setText(t.text + '.');
             }
         }
     }

--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -86,13 +86,16 @@ const DevTools = {
         if (v > 10) v = 10;
         this.cheats.timeScale = v;
 
+        // Engine treats smaller values as faster; invert so higher is faster
+        const applied = (v <= 0) ? 0 : 1 / v;
+
         const mgr = game?.scene;
         if (mgr && Array.isArray(mgr.scenes)) {
             for (let i = 0; i < mgr.scenes.length; i++) {
                 const sc = mgr.scenes[i];
                 try {
-                    if (sc.time) sc.time.timeScale = v;
-                    if (sc.physics && sc.physics.world) sc.physics.world.timeScale = v;
+                    if (sc.time) sc.time.timeScale = applied;
+                    if (sc.physics && sc.physics.world) sc.physics.world.timeScale = applied;
                 } catch {}
             }
         }
@@ -100,10 +103,11 @@ const DevTools = {
 
     applyTimeScale(scene) {
         const v = this.cheats.timeScale;
+        const applied = (v <= 0) ? 0 : 1 / v;
         if (!scene) return;
         try {
-            if (scene.time) scene.time.timeScale = v;
-            if (scene.physics && scene.physics.world) scene.physics.world.timeScale = v;
+            if (scene.time) scene.time.timeScale = applied;
+            if (scene.physics && scene.physics.world) scene.physics.world.timeScale = applied;
         } catch {}
     },
 

--- a/test/systems/DevTools.test.js
+++ b/test/systems/DevTools.test.js
@@ -4,7 +4,7 @@ import DevTools from '../../systems/DevTools.js';
 
 test('setMeleeSliceBatch clamps to 1 or 2', () => {
     DevTools.setMeleeSliceBatch(2);
-    assert.equal(DevTools.flags.meleeSliceBatch, 2);
+    assert.equal(DevTools.cheats.meleeSliceBatch, 2);
     DevTools.setMeleeSliceBatch(0);
-    assert.equal(DevTools.flags.meleeSliceBatch, 1);
+    assert.equal(DevTools.cheats.meleeSliceBatch, 1);
 });


### PR DESCRIPTION
## Summary
- fix inverted time scale so larger values speed up the game
- allow decimal entry in time scale field

## Technical Approach
- invert value applied in `DevTools.setTimeScale`/`applyTimeScale`
- permit `.` character when editing time scale in `DevUIScene._onKey`
- adjust DevTools unit test for updated API

## Performance
- no per-frame allocations; only existing cheat helpers touched

## Risks & Rollback
- edge case: entering 0 results in frozen time; revert commit `df14f6c` to undo

## QA Steps
- `npm test`
- open Dev UI and set Time Scale to `0.5` -> verify game slows
- set Time Scale to `2` -> verify game speeds up
- type `.` in Time Scale input; other non-numeric chars rejected

------
https://chatgpt.com/codex/tasks/task_e_68aa3eb8b4d48322a607bf9d14133452