### PR TITLE
feat: add rock1 and rock4 rock variants

### DIFF
--- a/data/itemDatabase.js
+++ b/data/itemDatabase.js
@@ -184,6 +184,104 @@ export const ITEM_DB = {
 
   //rocks
   //-----
+  rock1A: {
+    id: 'rock1A',
+    name: 'Small Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock1A', scale: 1.0, ox: 0, oy: 0 },
+    world: { textureKey: 'rock1A', scale: .65 },
+    collectible: true,          // custom flag for pickup
+    blocking: false,            // walk-through
+    givesItem: ITEM_IDS.SLINGSHOT_ROCK,
+    giveAmount: 1,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'common' },
+  },
+
+  rock1B: {
+    id: 'rock1B',
+    name: 'Medium Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock1B', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock1B',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 8, offsetX: 0, offsetY: -11, useScale: true, anchor: 'bottomCenter' }
+
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'uncommon' },
+  },
+
+  rock1C: {
+    id: 'rock1C',
+    name: 'Large Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock1C', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock1C',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 12, offsetX: 0, offsetY: -11, useScale: true, anchor: 'bottomCenter' }
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'rare' },
+  },
+
+  rock1D: {
+    id: 'rock1D',
+    name: 'Huge Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock1D', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock1D',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 18, offsetX: 0, offsetY: -12, useScale: true, anchor: 'bottomCenter' }
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'very_rare' },
+  },
+
+  rock1E: {
+    id: 'rock1E',
+    name: 'Giant Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock1E', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock1E',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 24, offsetX: 0, offsetY: -13, useScale: true, anchor: 'bottomCenter' }
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'legendary' },
+  },
+
   rock2A: {
     id: 'rock2A',
     name: 'Small Grassy Rock',
@@ -271,6 +369,104 @@ export const ITEM_DB = {
     icon:  { textureKey: 'rock2E', scale: 1.0, ox: 0, oy: 0 },
     world: {
       textureKey: 'rock2E',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 24, offsetX: 0, offsetY: -13, useScale: true, anchor: 'bottomCenter' }
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'legendary' },
+  },
+
+  rock4A: {
+    id: 'rock4A',
+    name: 'Small Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock4A', scale: 1.0, ox: 0, oy: 0 },
+    world: { textureKey: 'rock4A', scale: .65 },
+    collectible: true,          // custom flag for pickup
+    blocking: false,            // walk-through
+    givesItem: ITEM_IDS.SLINGSHOT_ROCK,
+    giveAmount: 1,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'common' },
+  },
+
+  rock4B: {
+    id: 'rock4B',
+    name: 'Medium Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock4B', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock4B',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 8, offsetX: 0, offsetY: -11, useScale: true, anchor: 'bottomCenter' }
+
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'uncommon' },
+  },
+
+  rock4C: {
+    id: 'rock4C',
+    name: 'Large Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock4C', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock4C',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 12, offsetX: 0, offsetY: -11, useScale: true, anchor: 'bottomCenter' }
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'rare' },
+  },
+
+  rock4D: {
+    id: 'rock4D',
+    name: 'Huge Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock4D', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock4D',
+      scale: 1.0,
+      origin: { x: 0.5, y: 1 },
+      body: { kind: 'circle', radius: 18, offsetX: 0, offsetY: -12, useScale: true, anchor: 'bottomCenter' }
+    },
+    collectible: false,
+    blocking: true,
+    depth: 1,
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'very_rare' },
+  },
+
+  rock4E: {
+    id: 'rock4E',
+    name: 'Giant Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: false,
+    maxStack: 1,
+    icon:  { textureKey: 'rock4E', scale: 1.0, ox: 0, oy: 0 },
+    world: {
+      textureKey: 'rock4E',
       scale: 1.0,
       origin: { x: 0.5, y: 1 },
       body: { kind: 'circle', radius: 24, offsetX: 0, offsetY: -13, useScale: true, anchor: 'bottomCenter' }

--- a/data/worldGenConfig.js
+++ b/data/worldGenConfig.js
@@ -35,11 +35,21 @@ export const WORLD_GEN = {
           minSpacing: 48,  // pixels between rock centers
           respawnDelayMs: { min: 5000, max: 7000 },
           variants: [
+            { id: 'rock1A', weight: 60 }, // collectible, non-blocking
+            { id: 'rock1B', weight: 20 }, // blocking
+            { id: 'rock1C', weight: 12 }, // blocking
+            { id: 'rock1D', weight: 6 },  // blocking
+            { id: 'rock1E', weight: 2 },  // blocking
             { id: 'rock2A', weight: 60 }, // collectible, non-blocking
             { id: 'rock2B', weight: 20 }, // blocking
             { id: 'rock2C', weight: 12 }, // blocking
             { id: 'rock2D', weight: 6 },  // blocking
             { id: 'rock2E', weight: 2 },  // blocking
+            { id: 'rock4A', weight: 60 }, // collectible, non-blocking
+            { id: 'rock4B', weight: 20 }, // blocking
+            { id: 'rock4C', weight: 12 }, // blocking
+            { id: 'rock4D', weight: 6 },  // blocking
+            { id: 'rock4E', weight: 2 },  // blocking
           ],
         },
         // Weighted tree variants

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -53,11 +53,21 @@ export default class MainScene extends Phaser.Scene {
         this.load.image('slingshot_rock', 'assets/weapons/slingshot_rock.png');
         this.load.image('crude_bat', 'assets/weapons/crude_bat.png');
         // resources
+        this.load.image('rock1A', 'assets/resources/rocks/rock1A.png');
+        this.load.image('rock1B', 'assets/resources/rocks/rock1B.png');
+        this.load.image('rock1C', 'assets/resources/rocks/rock1C.png');
+        this.load.image('rock1D', 'assets/resources/rocks/rock1D.png');
+        this.load.image('rock1E', 'assets/resources/rocks/rock1E.png');
         this.load.image('rock2A', 'assets/resources/rocks/rock2A.png');
         this.load.image('rock2B', 'assets/resources/rocks/rock2B.png');
         this.load.image('rock2C', 'assets/resources/rocks/rock2C.png');
         this.load.image('rock2D', 'assets/resources/rocks/rock2D.png');
         this.load.image('rock2E', 'assets/resources/rocks/rock2E.png');
+        this.load.image('rock4A', 'assets/resources/rocks/rock4A.png');
+        this.load.image('rock4B', 'assets/resources/rocks/rock4B.png');
+        this.load.image('rock4C', 'assets/resources/rocks/rock4C.png');
+        this.load.image('rock4D', 'assets/resources/rocks/rock4D.png');
+        this.load.image('rock4E', 'assets/resources/rocks/rock4E.png');
         // trees
         this.load.image('tree1A', 'assets/resources/trees/tree1A.png');
         this.load.image('tree1B', 'assets/resources/trees/tree1B.png');


### PR DESCRIPTION
## Summary
- add rock1A–E and rock4A–E resources
- allow rock1A and rock4A to drop slingshot rocks
- preload new rock textures and expand world gen variants

## Technical Approach
- duplicated rock2 entries in `data/itemDatabase.js`
- extended `spawns.resources.rocks.variants` in `data/worldGenConfig.js`
- loaded new assets in `scenes/MainScene.js`

## Performance
- data additions only; no runtime allocations

## Risks & Rollback
- Incorrect asset paths or spawn weights could cause missing textures or imbalanced spawns
- Revert commit `a64984b` if issues arise

## QA Steps
- npm test (fails: setMeleeSliceBatch clamps to 1 or 2)
- run game and verify new rock variants appear, with A variants collectible and granting slingshot rocks


------
https://chatgpt.com/codex/tasks/task_e_68aa3edda3548322a8b11612bdc80581