### PR TITLE
fix(time): apply multiplier to cooldowns

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -215,8 +215,9 @@ export default class DevUIScene extends Phaser.Scene {
         const minus = this._makeButton(minusX, y + 9, 26, 26, '–', () => this._bumpTimeScale(-0.1), 2);
         this._timeText = this._makeEditableNumber(minusX + 30, y + 9, 60, 26, () => this._time.scale, (s) => { this._time.scale = s; this._commitTimeScale(); });
         const plus = this._makeButton(minusX + 94, y + 9, 26, 26, '+', () => this._bumpTimeScale(0.1), 2);
+        const set = this._makeButton(minusX + 130, y + 7, 60, 30, 'Set', () => this._commitTimeScale(), 2, UI.okColor);
 
-        this.content.add([card, label, minus, this._timeText.box, plus]);
+        this.content.add([card, label, minus, this._timeText.box, plus, set]);
         return y + UI.rowH;
     }
 

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -324,7 +324,7 @@ export default class MainScene extends Phaser.Scene {
         const spend = Math.min(this.stamina, amount);
         if (spend > 0) {
             this.stamina -= spend;
-            this._lastStaminaSpendTime = this.time.now;
+            this._lastStaminaSpendTime = DevTools.now(this);
             this.uiScene?.updateStamina?.(this.stamina);
         }
         return spend;
@@ -337,7 +337,7 @@ export default class MainScene extends Phaser.Scene {
     regenStamina(deltaMs) {
         if (this._isSprinting || this.isCharging) return;
         if (
-            this.time.now - this._lastStaminaSpendTime <
+            DevTools.now(this) - this._lastStaminaSpendTime <
             this._staminaRegenDelayMs
         )
             return;
@@ -455,7 +455,7 @@ export default class MainScene extends Phaser.Scene {
 
         // Zombie pursuit (simple: slide → then stun → then chase)
         this.zombies.getChildren().forEach((zombie) => {
-            const now = this.time.now;
+            const now = DevTools.now(this);
 
             const inKnockback = (zombie.knockbackUntil || 0) > now;
             const stunned = (zombie.stunUntil || 0) > now && !inKnockback; // stun begins after slide
@@ -688,7 +688,7 @@ export default class MainScene extends Phaser.Scene {
 
         // Raw 0..1 charge based on time held
         const heldMs = Phaser.Math.Clamp(
-            this.time.now - this.chargeStart,
+            DevTools.now(this) - this.chargeStart,
             0,
             this.chargeMaxMs,
         );

--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -369,7 +369,7 @@ export default class UIScene extends Phaser.Scene {
         // NEW: cooldown overlays (e.g., bat swings)
         this.events.on('weapon:cooldownStart', ({ itemId, durationMs }) => {
             if (!itemId || !durationMs || durationMs <= 0) return;
-            const now = this.time.now;
+            const now = DevTools.now(this);
             this._activeCooldowns.set(itemId, { start: now, end: now + durationMs });
             this.#syncCooldownOverlays();
         });
@@ -736,7 +736,7 @@ export default class UIScene extends Phaser.Scene {
     // Create/ensure overlays for any slots showing items currently on cooldown,
     // and remove overlays that no longer match or have expired.
     #syncCooldownOverlays() {
-        const now = this.time.now;
+        const now = DevTools.now(this);
 
         // Remove expired item cooldowns
         for (const [itemId, cd] of this._activeCooldowns) {
@@ -802,7 +802,7 @@ export default class UIScene extends Phaser.Scene {
             const o = this._slotOverlays[i];
             const key = `${o.kind}:${o.index}:${o.itemId}`;
             const cd = this._activeCooldowns.get(o.itemId);
-            const alive = cd && this.time.now < cd.end;
+            const alive = cd && DevTools.now(this) < cd.end;
             if (!alive || !need.has(key)) {
                 this.#removeOverlay(o, i);
             }
@@ -840,7 +840,7 @@ export default class UIScene extends Phaser.Scene {
     #updateCooldownOverlays() {
         if (this._slotOverlays.length === 0) return;
 
-        const now = this.time.now;
+        const now = DevTools.now(this);
         for (let i = this._slotOverlays.length - 1; i >= 0; i--) {
             const o = this._slotOverlays[i];
             const cd = this._activeCooldowns.get(o.itemId);

--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -111,6 +111,15 @@ const DevTools = {
         } catch {}
     },
 
+    // Get scaled time in ms honoring the dev time multiplier
+    now(scene) {
+        const base = scene?.time?.now || 0;
+        const applied = scene?.time?.timeScale || 1;
+        const scale = this.cheats.timeScale || 1;
+        if (applied <= 0) return base;
+        return (base / applied) * scale;
+    },
+
     // Toggle entry point used by Dev UI
     setShowHitboxes(value, scene) {
         this.cheats.showHitboxes = !!value;
@@ -143,7 +152,7 @@ const DevTools = {
         if (!this.cheats.showHitboxes) return;
         this._ensureLayers(scene);
 
-        const now = scene.time.now | 0;
+        const now = this.now(scene) | 0;
         if (now - this._lastFastDraw >= this._FAST_MS) {
             this._drawFast(scene);
             this._lastFastDraw = now;
@@ -238,7 +247,7 @@ const DevTools = {
         if (mh && mh.children?.iterate) {
             const N     = Math.max(1, (this._MELEE_SUBDIV | 0));                 // total slices across cone
             const batch = Math.max(1, (this.cheats.meleeSliceBatch | 0)) > 1 ? 2 : 1; // 1 or 2
-            const now   = scene.time.now | 0;
+            const now   = this.now(scene) | 0;
 
             mh.children.iterate((hit) => {
                 if (!hit || !hit.active) return;

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -79,7 +79,7 @@ export default function createCombatSystem(scene) {
     function handlePlayerZombieCollision(player, zombie) {
         if (scene.isGameOver) return;
         if (DevTools?.isPlayerInvisible?.() === true) return;
-        const now = scene.time.now | 0;
+        const now = DevTools.now(scene) | 0;
         const hitCdMs = 500;
         if (!zombie.lastHitTime) zombie.lastHitTime = 0;
         if (now - zombie.lastHitTime < hitCdMs) return;
@@ -260,7 +260,7 @@ export default function createCombatSystem(scene) {
                 ? Math.floor(baseCd * st.lowCooldownMultiplier)
                 : baseCd;
         if (!DevTools.cheats.noCooldown && cdMs > 0) {
-            scene._nextRangedReadyTime = scene.time.now + cdMs;
+            scene._nextRangedReadyTime = DevTools.now(scene) + cdMs;
             scene.uiScene?.events?.emit('weapon:cooldownStart', {
                 itemId: equipped.id,
                 durationMs: cdMs,
@@ -286,7 +286,7 @@ export default function createCombatSystem(scene) {
         if (scene._isSwinging) return;
         const effectiveCooldownMs =
             scene._nextSwingCooldownMs ?? baseCooldownMs;
-        const now = scene.time.now;
+        const now = DevTools.now(scene);
         if (now - (scene._lastSwingEndTime || 0) < effectiveCooldownMs) return;
         const st = wpn?.stamina;
         let lowStamina = false;
@@ -371,7 +371,7 @@ export default function createCombatSystem(scene) {
         cone.setData('aimAngle', startRot);
         cone.setData('coneHalfRad', halfArc);
         cone.setData('maxRange', range);
-        cone.setData('swingStartMs', scene.time.now | 0);
+        cone.setData('swingStartMs', DevTools.now(scene) | 0);
         cone.setData('swingDurationMs', swingDurationMs | 0);
         scene._isSwinging = true;
         const swing = { t: 0 };
@@ -394,7 +394,7 @@ export default function createCombatSystem(scene) {
             },
             onComplete: () => {
                 scene._isSwinging = false;
-                scene._lastSwingEndTime = scene.time.now;
+                scene._lastSwingEndTime = DevTools.now(scene);
                 if (scene.batSprite) {
                     scene.batSprite.destroy();
                     scene.batSprite = null;
@@ -545,7 +545,7 @@ export default function createCombatSystem(scene) {
         const vx = (dx / len) * impulse;
         const vy = (dy / len) * impulse;
         zombie.setVelocity(vx, vy);
-        const now = scene.time.now | 0;
+        const now = DevTools.now(scene) | 0;
         zombie.knockbackUntil = now + 120;
         if (baseKb >= (zombie.staggerThreshold || 99999)) {
             zombie.stunUntil = now + (zombie.stunDurationMs || 300);

--- a/systems/dayNightSystem.js
+++ b/systems/dayNightSystem.js
@@ -1,12 +1,13 @@
 // systems/dayNightSystem.js
 // Day/Night cycle logic isolated from Phaser scene for reuse.
 import { WORLD_GEN } from '../data/worldGenConfig.js';
+import DevTools from './DevTools.js';
 
 export default function createDayNightSystem(scene) {
     // ----- Phase Transitions -----
     function startDay() {
         scene.phase = 'day';
-        scene.phaseStartTime = scene.time.now;
+        scene.phaseStartTime = DevTools.now(scene);
         scene._phaseElapsedMs = 0;
         if (scene.nightWaveTimer) {
             scene.nightWaveTimer.remove(false);
@@ -19,7 +20,7 @@ export default function createDayNightSystem(scene) {
 
     function startNight() {
         scene.phase = 'night';
-        scene.phaseStartTime = scene.time.now;
+        scene.phaseStartTime = DevTools.now(scene);
         scene._phaseElapsedMs = 0;
         if (scene.spawnZombieTimer) {
             scene.spawnZombieTimer.remove(false);

--- a/systems/inputSystem.js
+++ b/systems/inputSystem.js
@@ -17,7 +17,7 @@ export default function createInputSystem(scene) {
 
         if (cat === 'melee' && equipped.id === 'crude_bat') {
             const wpn = def.weapon || {};
-            const now = scene.time.now;
+            const now = DevTools.now(scene);
             const baseCd = wpn?.swingCooldownMs ?? 80;
             const effectiveCd = scene._nextSwingCooldownMs ?? baseCd;
             const lastEnd = scene._lastSwingEndTime || 0;
@@ -41,7 +41,7 @@ export default function createInputSystem(scene) {
 
         if (cat === 'ranged' && equipped.id === 'slingshot') {
             const wpn = def.weapon || {};
-            const now = scene.time.now;
+            const now = DevTools.now(scene);
             const fireCd = wpn?.fireCooldownMs ?? 0;
             if (
                 !DevTools.cheats.noCooldown &&
@@ -76,7 +76,7 @@ export default function createInputSystem(scene) {
         }
 
         const heldMs = Phaser.Math.Clamp(
-            scene.time.now - scene.chargeStart,
+            DevTools.now(scene) - scene.chargeStart,
             0,
             scene.chargeMaxMs,
         );


### PR DESCRIPTION
## Summary
- add Set button to Dev UI time controls
- scale cooldowns and attack speeds by time multiplier

## Technical Approach
- `DevUIScene._timeControlRow` adds a Set button
- `DevTools.now` returns scaled time; combat and input systems use it

## Performance
- helper returns primitives; only math in update loops

## Risks & Rollback
- if time behavior breaks, revert commit 0ab11f4

## QA Steps
- `npm test`
- open Dev UI → adjust time scale → press Set
- verify attack speeds and cooldown overlays change accordingly


------
https://chatgpt.com/codex/tasks/task_e_68ab997add408322a31f222c07f74b15