### PR TITLE
feat: add inventory item spawner to Dev Tools

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -354,6 +354,30 @@ const DevTools = {
         }
     },
 
+    // Try to add items to inventory; drop leftovers at player position
+    spawnItemsSmart(scene, id, qty = 1) {
+        qty = Math.max(1, qty | 0);
+        const game = scene?.game;
+        if (!game || !game.events) return;
+
+        const reg = scene.registry;
+        let prev = 0;
+        if (reg) { prev = reg.get('inv:addedCount') | 0; reg.set('inv:addedCount', 0); }
+
+        game.events.emit('inv:add', { id, qty, where: 'inventory' });
+
+        let added = qty;
+        if (reg) { added = reg.get('inv:addedCount') | 0; reg.set('inv:addedCount', prev + added); }
+
+        const leftover = qty - added;
+        if (leftover > 0) {
+            const pos = { x: scene.player?.x || 0, y: scene.player?.y || 0 };
+            for (let i = 0; i < leftover; i++) {
+                game.events.emit('dev:drop-item', { id, pos });
+            }
+        }
+    },
+
 };
 
 export default DevTools;


### PR DESCRIPTION
## Summary
- add Spawn Item dev tool to give items directly to inventory
- implement `spawnItemsSmart` helper to add or drop items based on stack size

## Technical Approach
- build item index and UI row in `scenes/DevUIScene.js`
- add inventory spawn helper in `systems/DevTools.js`

## Performance
- dev-only feature; no per-frame allocations or update math changes

## Risks & Rollback
- new UI paths could mis-handle item data; revert commit to remove

## QA Steps
- `npm test`
- open Dev UI, search for an item, set amount within max stack, click Spawn and confirm item appears in inventory


------
https://chatgpt.com/codex/tasks/task_e_68aba06e7cf883228b3bd61f87bf46be