### PR TITLE
fix: align item spawner and add inventory placement

### DIFF
--- a/data/itemDatabase.js
+++ b/data/itemDatabase.js
@@ -154,11 +154,11 @@ export const ITEM_DB = {
   // Ammo
   //-------------------------------
 
-  //slingshot rock
-  //--------------
+  //slingshot ammo
+  //-------------
   [ITEM_IDS.SLINGSHOT_ROCK]: {
     id: ITEM_IDS.SLINGSHOT_ROCK,
-    name: 'Rock',
+    name: 'Slingshot Ammo',
     type: ITEM_TYPES.AMMO,
     stackable: true,
     maxStack: 99,

--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -212,6 +212,7 @@ export default class DevUIScene extends Phaser.Scene {
         const typeInputX = typeLabelX + typeLbl.displayWidth + 8;
         const typeInputW = 180;
 
+        this._enemyTypeInputX = typeInputX;
         this._makeTypeaheadBox(typeInputX, y + 9, typeInputW, 26);
 
         // Count controls
@@ -235,7 +236,7 @@ export default class DevUIScene extends Phaser.Scene {
 
         const typeLabelX = 135;
         const typeLbl = this.add.text(typeLabelX, y + 12, 'Item:', UI.font).setDepth(2);
-        const typeInputX = typeLabelX + typeLbl.displayWidth + 8;
+        const typeInputX = (this._enemyTypeInputX ?? (typeLabelX + typeLbl.displayWidth + 8));
         const typeInputW = 180;
 
         this._makeItemTypeaheadBox(typeInputX, y + 9, typeInputW, 26);
@@ -1011,6 +1012,10 @@ export default class DevUIScene extends Phaser.Scene {
             this._item.lastConfirmedKey = chosen.key;
             this._item.lastConfirmedName = chosen.name;
             this._item.maxStack = chosen.maxStack || 1;
+            if ((parseInt(this._item.count, 10) || 1) > this._item.maxStack) {
+                this._item.count = String(this._item.maxStack);
+                this._itemCountText?.set?.(this._item.count);
+            }
             this._itemTypeBox.set(chosen.name);
         } else {
             this._itemTypeBox.set(this._item.lastConfirmedName);

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -309,6 +309,25 @@ export default class MainScene extends Phaser.Scene {
         return this.resourceSystem.spawnAllResources();
     }
 
+    addItemToInventory(id, qty = 1, _where = 'inventory') {
+        const inv = this.uiScene?.inventory;
+        if (!inv || !id) return 0;
+
+        const count = (arr) => {
+            let total = 0;
+            for (let i = 0; i < arr.length; i++) {
+                const s = arr[i];
+                if (s && s.id === id) total += s.count;
+            }
+            return total;
+        };
+
+        const before = count(inv.grid) + count(inv.hotbar);
+        inv.addItem(id, qty);
+        const after = count(inv.grid) + count(inv.hotbar);
+        return after - before;
+    }
+
     // ==========================
     // STAMINA HELPERS
     // ==========================

--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -354,7 +354,7 @@ const DevTools = {
         }
     },
 
-    // Try to add items to inventory; drop leftovers at player position
+    // Try to add items to inventory; ignore leftovers if inventory is full
     spawnItemsSmart(scene, id, qty = 1) {
         qty = Math.max(1, qty | 0);
         const game = scene?.game;
@@ -369,13 +369,7 @@ const DevTools = {
         let added = qty;
         if (reg) { added = reg.get('inv:addedCount') | 0; reg.set('inv:addedCount', prev + added); }
 
-        const leftover = qty - added;
-        if (leftover > 0) {
-            const pos = { x: scene.player?.x || 0, y: scene.player?.y || 0 };
-            for (let i = 0; i < leftover; i++) {
-                game.events.emit('dev:drop-item', { id, pos });
-            }
-        }
+        // Ignore leftovers when inventory + hotbar are full
     },
 
 };


### PR DESCRIPTION
## Summary
- align item spawn UI with zombie spawner
- rename slingshot rock to "Slingshot Ammo"
- auto-clamp dev item quantity to selected item's max stack
- spawn items into first open inventory slot then hotbar

## Technical Approach
- adjust `DevUIScene` layout and selection logic
- rename item in `itemDatabase`
- add `addItemToInventory` helper and ignore spawn leftovers

## Performance
- loops only on dev actions; no per-frame allocations

## Risks & Rollback
- minimal; revert via `git revert <commit>`

## QA Steps
- open Dev UI and confirm item spawner aligns with zombie spawner
- select different items; count clamps to max stack
- spawn items and verify inventory/hotbar receive them


------
https://chatgpt.com/codex/tasks/task_e_68aba51353b48322a3baeb0e6c6d58de