### PR TITLE
Fix cooldown timing, slingshot scaling, and dev UI glitches

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -56,6 +56,16 @@ const DevTools = {
         };
     },
 
+    _getItemSpawnPrefs() { return this._itemSpawnPrefs || null; },
+    _setItemSpawnPrefs(p) {
+        if (!p) return;
+        this._itemSpawnPrefs = {
+            key:  p.key  || p.selectedKey || p.itemId,
+            name: p.name || p.selectedName,
+            count: (p.count == null ? '1' : String(p.count))
+        };
+    },
+
     // reset dev toggles to defaults (used on death)
     resetToDefaults(scene = null) {
         this.cheats.showHitboxes   = false;
@@ -111,13 +121,11 @@ const DevTools = {
         } catch {}
     },
 
-    // Get scaled time in ms honoring the dev time multiplier
+    // Get unscaled game time in ms (independent of scene timeScale)
     now(scene) {
-        const base = scene?.time?.now || 0;
-        const applied = scene?.time?.timeScale || 1;
-        const scale = this.cheats.timeScale || 1;
-        if (applied <= 0) return base;
-        return (base / applied) * scale;
+        const loop = scene?.sys?.game?.loop;
+        if (loop && typeof loop.time === 'number') return loop.time;
+        return scene?.time?.now || 0;
     },
 
     // Toggle entry point used by Dev UI

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -233,9 +233,10 @@ export default function createCombatSystem(scene) {
         const v = scene.physics.velocityFromRotation(angle, speed);
         bullet.setVelocity(v.x, v.y);
         bullet.setRotation(angle);
+        const ts = scene.physics?.world?.timeScale || 1; // account for slow/fast physics
         const lifetimeMs = Math.max(
             1,
-            Math.floor((travel / Math.max(1, speed)) * 1000),
+            Math.floor((travel / Math.max(1, speed)) * 1000 * ts),
         );
         scene.time.delayedCall(lifetimeMs, () => {
             if (bullet.active && bullet.destroy) bullet.destroy();


### PR DESCRIPTION
## Summary
- freeze weapon cooldowns during pause and stabilize charge timing
- keep projectile distance consistent across time scale changes
- fix Dev UI typeahead click targets and persist item spawn selection
- cap ammo display at `+99`

## Technical Approach
- track pause intervals in `MainScene` and shift cooldown timestamps on resume
- switch `DevTools.now` to use unscaled loop time and add item spawn prefs
- adjust projectile lifetime by physics `timeScale`
- rebuild Dev UI dropdown rows with correct local hitboxes and save last item input
- right-align ammo labels and clamp counts in `UIScene`

## Performance
- reused existing objects; no per-frame allocations added

## Risks & Rollback
- pause/resume math may miss edge cases if additional timers are added later
- UI alignment tweaks could misplace labels on non-default fonts
- revert via `git revert 485bedb`

## QA Steps
- pause the game mid-cooldown; resume and confirm timer resumes where it left off
- set time scale <0.4 and fire slingshot; charge bar should not flicker
- reduce time scale and fire bullets; they should travel the same distance
- open Dev UI, use type search to select an item; selection should register every time
- spawn an item, close Dev UI, reopen and verify last item & amount persist
- stock >99 ammo and verify HUD shows `+99` with digits stationary


------
https://chatgpt.com/codex/tasks/task_e_68aba789eecc8322a10e1e81aec4a7d9