### PR TITLE
fix(dev-ui): avoid redeclared startCount and canvas readbacks

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -6,7 +6,16 @@ import DevUIScene from './scenes/DevUIScene.js';
 const BASE_WIDTH = 800;   // base game width (designed pixel resolution)
 const BASE_HEIGHT = 600;  // base game height
 
+// 🖼️ Explicit canvas with willReadFrequently to avoid readback warnings
+const canvas = (typeof document !== 'undefined')
+    ? document.createElement('canvas')
+    : null;
+if (canvas) {
+    canvas.setAttribute('willReadFrequently', 'true');
+}
+
 const config = {
+    ...(canvas ? { canvas } : {}),
     type: Phaser.WEBGL, // Force WebGL renderer
     width: BASE_WIDTH,
     height: BASE_HEIGHT,

--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -44,9 +44,9 @@ export default class DevUIScene extends Phaser.Scene {
         // Load saved prefs (if any) from DevTools
         const saved = (DevTools._getEnemySpawnPrefs && DevTools._getEnemySpawnPrefs()) || null;
 
-        const startKey   = saved?.key   || first.key;
-        const startName  = saved?.name  || first.name;
-        const startCount = (saved?.count != null ? String(saved.count) : '1');
+        const startKey       = saved?.key   || first.key;
+        const startName      = saved?.name  || first.name;
+        const startEnemyCount = (saved?.count != null ? String(saved.count) : '1');
 
         this._enemy = {
             // selection model
@@ -62,7 +62,7 @@ export default class DevUIScene extends Phaser.Scene {
             resHL: 0,                                // highlighted result in view
 
             // amount model (string so user can blank it)
-            count: startCount,
+            count: startEnemyCount,
         };
 
         // Build item index for inventory spawning
@@ -71,10 +71,10 @@ export default class DevUIScene extends Phaser.Scene {
             ? this._iIndex.sortedEntries[0]
             : { key: '', name: '', lower: '', maxStack: 1 };
         const savedItem = (DevTools._getItemSpawnPrefs && DevTools._getItemSpawnPrefs()) || null;
-        const startItemKey = savedItem?.key || firstItem.key;
-        const startItemName = savedItem?.name || firstItem.name;
-        const entry = this._iIndex.entries.find(e => e.key === startItemKey) || firstItem;
-        const startCount = savedItem?.count != null ? String(savedItem.count) : '1';
+        const startItemKey   = savedItem?.key   || firstItem.key;
+        const startItemName  = savedItem?.name  || firstItem.name;
+        const entry          = this._iIndex.entries.find(e => e.key === startItemKey) || firstItem;
+        const startItemCount = savedItem?.count != null ? String(savedItem.count) : '1';
 
         this._item = {
             selectedKey: startItemKey,
@@ -88,7 +88,7 @@ export default class DevUIScene extends Phaser.Scene {
             resStart: 0,
             resHL: 0,
 
-            count: startCount,
+            count: startItemCount,
         };
 
         this._time = { scale: String(DevTools.cheats.timeScale || 1) };


### PR DESCRIPTION
## Summary
- fix duplicate `startCount` declarations that crashed Dev UI
- mark Phaser canvas with `willReadFrequently` to quiet Chrome readback warnings

## Technical Approach
- rename count variables in `DevUIScene.init`
- create explicit canvas in `bootstrap.js` and pass to Phaser config

## Performance
- no per-frame allocations; canvas flag reduces expensive readbacks

## Risks & Rollback
- if canvas flag causes issues, remove custom canvas creation

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abb1b10d3c83229b5ae92db8cc9d42