### PR TITLE
fix(cooldown): pause stamina regen delay during game pause

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -264,6 +264,7 @@ export default class MainScene extends Phaser.Scene {
                 if (this._nextRangedReadyTime) this._nextRangedReadyTime += diff;
                 if (this._lastSwingEndTime) this._lastSwingEndTime += diff;
                 if (this.isCharging) this.chargeStart += diff;
+                if (this._lastStaminaSpendTime) this._lastStaminaSpendTime += diff;
             }
         });
 


### PR DESCRIPTION
## Summary
- ensure stamina regen cooldown doesn't advance while gameplay is paused

## Technical Approach
- adjust `scenes/MainScene.js` pause/resume handler to shift `_lastStaminaSpendTime` by the pause duration

## Performance
- only constant-time arithmetic on resume, no per-frame allocations

## Risks & Rollback
- minor: stamina regen could be delayed if `_lastStaminaSpendTime` is stale; revert commit `8599c9e` to undo

## QA Steps
- spend stamina (sprint)
- pause the game
- wait a few seconds
- resume and confirm stamina hasn't regenerated until the normal delay passes

------
https://chatgpt.com/codex/tasks/task_e_68abb3e866c48322a834d01dc0245d7b