### PR TITLE
fix(charge): scale weapon charge by game speed

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -729,8 +729,9 @@ export default class MainScene extends Phaser.Scene {
         if (!wpnDef || wpnDef.canCharge !== true) return;
 
         // Raw 0..1 charge based on time held
+        const scale = DevTools.cheats.timeScale || 1;
         const heldMs = Phaser.Math.Clamp(
-            DevTools.now(this) - this.chargeStart,
+            (DevTools.now(this) - this.chargeStart) * scale,
             0,
             this.chargeMaxMs,
         );

--- a/systems/inputSystem.js
+++ b/systems/inputSystem.js
@@ -75,8 +75,9 @@ export default function createInputSystem(scene) {
             return;
         }
 
+        const scale = DevTools.cheats.timeScale || 1;
         const heldMs = Phaser.Math.Clamp(
-            DevTools.now(scene) - scene.chargeStart,
+            (DevTools.now(scene) - scene.chargeStart) * scale,
             0,
             scene.chargeMaxMs,
         );


### PR DESCRIPTION
## Summary
- scale weapon charge durations by the global time scale so game speed affects charging
- keep slingshot charge behaviour stable across different speeds

## Technical Approach
- multiply elapsed charge time by `DevTools.cheats.timeScale` in `systems/inputSystem.js` and `scenes/MainScene.js`

## Performance
- uses a simple multiplier without extra allocations or per-frame objects

## Risks & Rollback
- changing time scale mid-charge may lead to minor discrepancies
- revert commit `5e4117a` if issues arise

## QA Steps
- launch the game
- change the time scale in the Dev UI
- hold and release the slingshot; observe charge bar and shot power scale with game speed


------
https://chatgpt.com/codex/tasks/task_e_68abb40587e48322986ffce7100f3e22