### PR TITLE
Fix projectile range scaling with game speed

### DIFF
--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -233,10 +233,10 @@ export default function createCombatSystem(scene) {
         const v = scene.physics.velocityFromRotation(angle, speed);
         bullet.setVelocity(v.x, v.y);
         bullet.setRotation(angle);
-        const ts = scene.physics?.world?.timeScale || 1; // account for slow/fast physics
+        const ts = scene.physics?.world?.timeScale || 1; // adjust for slow/fast physics
         const lifetimeMs = Math.max(
             1,
-            Math.floor((travel / Math.max(1, speed)) * 1000 * ts),
+            Math.floor((travel / Math.max(1, speed)) * 1000 / ts),
         );
         scene.time.delayedCall(lifetimeMs, () => {
             if (bullet.active && bullet.destroy) bullet.destroy();


### PR DESCRIPTION
Summary:
- ensure projectile range doesn't shrink when physics timeScale slows

Technical Approach:
- systems/combatSystem.js: divide projectile lifetime by physics timeScale to maintain travel distance

Performance:
- math-only adjustment; no extra allocations or per-frame cost

Risks & Rollback:
- if physics timeScale is 0, lifetime uses default scale; revert commit if issues arise

QA Steps:
- start game
- reduce game speed (e.g., set `scene.physics.world.timeScale` below 1)
- fire slingshot and confirm travel distance matches normal speed
- restore game speed and verify range unchanged


------
https://chatgpt.com/codex/tasks/task_e_68abb421c2688322b90cd30aaf776757