### PR TITLE
fix: freeze weapon cooldowns during pause

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -266,6 +266,7 @@ export default class MainScene extends Phaser.Scene {
                 if (this.isCharging) this.chargeStart += diff;
                 if (this._lastStaminaSpendTime) this._lastStaminaSpendTime += diff;
             }
+            this._pauseStart = 0;
         });
 
         // Night overlay

--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -47,6 +47,7 @@ export default class UIScene extends Phaser.Scene {
                         cd.end += diff;
                     }
                 }
+                this._pauseStart = 0;
             };
             main.events.on(Phaser.Scenes.Events.PAUSE, onPause);
             main.events.on(Phaser.Scenes.Events.RESUME, onResume);
@@ -759,7 +760,7 @@ export default class UIScene extends Phaser.Scene {
     // Create/ensure overlays for any slots showing items currently on cooldown,
     // and remove overlays that no longer match or have expired.
     #syncCooldownOverlays() {
-        const now = DevTools.now(this);
+        const now = this._pauseStart || DevTools.now(this);
 
         // Remove expired item cooldowns
         for (const [itemId, cd] of this._activeCooldowns) {
@@ -825,7 +826,7 @@ export default class UIScene extends Phaser.Scene {
             const o = this._slotOverlays[i];
             const key = `${o.kind}:${o.index}:${o.itemId}`;
             const cd = this._activeCooldowns.get(o.itemId);
-            const alive = cd && DevTools.now(this) < cd.end;
+            const alive = cd && now < cd.end;
             if (!alive || !need.has(key)) {
                 this.#removeOverlay(o, i);
             }
@@ -863,7 +864,7 @@ export default class UIScene extends Phaser.Scene {
     #updateCooldownOverlays() {
         if (this._slotOverlays.length === 0) return;
 
-        const now = DevTools.now(this);
+        const now = this._pauseStart || DevTools.now(this);
         for (let i = this._slotOverlays.length - 1; i >= 0; i--) {
             const o = this._slotOverlays[i];
             const cd = this._activeCooldowns.get(o.itemId);


### PR DESCRIPTION
## Summary
- ensure weapon cooldown timers and UI overlays stop while the game is paused
- reset pause timestamps on resume to avoid drift

## Technical Approach
- adjust MainScene resume handler to zero `_pauseStart`
- freeze UIScene cooldown overlay logic when `_pauseStart` is set

## Performance
- only minor timestamp math; no per-frame allocations

## Risks & Rollback
- cooldown overlays might desync if additional pause sources are introduced; revert via `git revert be6f333`

## QA Steps
- start a cooldown then open pause menu
- verify UI overlay and cooldown timer remain frozen
- resume and ensure cooldown continues from where it paused

------
https://chatgpt.com/codex/tasks/task_e_68abb692dd708322b5fb81c65a1cc752