### PR TITLE
fix(cooldown): scale cooldowns with game speed

### DIFF
--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -261,10 +261,12 @@ export default function createCombatSystem(scene) {
                 ? Math.floor(baseCd * st.lowCooldownMultiplier)
                 : baseCd;
         if (!DevTools.cheats.noCooldown && cdMs > 0) {
-            scene._nextRangedReadyTime = DevTools.now(scene) + cdMs;
+            const scale = DevTools.cheats.timeScale || 1;
+            const dur = Math.floor(cdMs / scale);
+            scene._nextRangedReadyTime = DevTools.now(scene) + dur;
             scene.uiScene?.events?.emit('weapon:cooldownStart', {
                 itemId: equipped.id,
-                durationMs: cdMs,
+                durationMs: dur,
             });
         }
         scene.uiScene?.events?.emit('weapon:chargeEnd');
@@ -306,7 +308,10 @@ export default function createCombatSystem(scene) {
         }
         const cooldownMult =
             lowStamina && st ? (st.cooldownMultiplier ?? 6) : 1;
-        scene._nextSwingCooldownMs = Math.floor(baseCooldownMs * cooldownMult);
+        const scale = DevTools.cheats.timeScale || 1;
+        scene._nextSwingCooldownMs = Math.floor(
+            (baseCooldownMs * cooldownMult) / scale,
+        );
         const canCharge = wpn?.canCharge === true;
         let charge = canCharge
             ? Phaser.Math.Clamp(chargePercent || 0, 0, 1)


### PR DESCRIPTION
## Summary
- scale ranged and melee weapon cooldowns with global time multiplier

## Technical Approach
- divide cooldown durations by `DevTools.cheats.timeScale` in `fireRangedWeapon` and `swingBat`

## Performance
- simple math once per attack; no per-frame allocations

## Risks & Rollback
- cooldowns may desync if time scale changes mid-cooldown
- rollback: revert commit adff24e

## QA Steps
- Run `npm test`
- In game, change the time scale cheat and confirm weapon cooldown overlays shrink or grow accordingly

------
https://chatgpt.com/codex/tasks/task_e_68abb6f199bc8322909b6845d1d4157c