### PR TITLE
fix: render rock tops above player

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -117,6 +117,17 @@ export default function createResourceSystem(scene) {
             const blocking = !!def.blocking;
             obj.setData('blocking', blocking);
 
+            if (blocking && def.tags?.includes('rock')) {
+                const top = scene.add
+                    .image(x, y, def.world?.textureKey || id)
+                    .setOrigin(originX, originY)
+                    .setScale(scale)
+                    .setDepth((scene.player?.depth ?? 900) + 2)
+                    .setCrop(0, 0, obj.width, obj.height * 0.5);
+                obj.setData('topSprite', top);
+                obj.once('destroy', () => top.destroy());
+            }
+
             if (def.tags?.includes('bush')) obj.setData('bush', true);
 
             const bodyCfg = def.world?.body;


### PR DESCRIPTION
Summary:
- ensure blocking rocks occlude the player by drawing their top halves above the player layer.

Technical Approach:
- systems/resourceSystem.js: in createResourceAt, spawn a cropped overlay sprite for blocking rocks with depth above the player and destroy it with the base resource.

Performance:
- overlay sprites are created once per rock and reused until the rock is destroyed; no per-frame allocations.

Risks & Rollback:
- incorrect crop values could misalign sprites; revert commit 8d67da7 if rendering issues arise.

QA Steps:
- run `npm test`
- start the game and walk around rocks to confirm the player appears behind rock tops.


------
https://chatgpt.com/codex/tasks/task_e_68abb77f76048322a6e4a0bb8d4acd34