### PR TITLE
feat: clamp dev item spawn by stack size

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -4,6 +4,8 @@
 // - ~10 Hz: resources (YELLOW)
 // - Melee cones draw as time-synced thin slices. Batch size (1 or 2) is configurable.
 
+import { ITEM_DB } from '../data/itemDatabase.js';
+
 const DevTools = {
     // ─────────────────────────────────────────────────────────────
     // CHEATS (wired from Dev UI)
@@ -364,7 +366,8 @@ const DevTools = {
 
     // Try to add items to inventory; ignore leftovers if inventory is full
     spawnItemsSmart(scene, id, qty = 1) {
-        qty = Math.max(1, qty | 0);
+        const max = ITEM_DB[id]?.maxStack || 1;
+        qty = Math.max(1, Math.min(qty | 0, max));
         const game = scene?.game;
         if (!game || !game.events) return;
 


### PR DESCRIPTION
Summary:
- cap DevTools.item spawner by per-item max stack to match inventory limits.

Technical Approach:
- systems/DevTools.js: import ITEM_DB and limit spawnItemsSmart quantity to ITEM_DB maxStack.

Performance:
- simple arithmetic in a dev helper; no per-frame impact.

Risks & Rollback:
- affects only dev spawning; revert commit fef41fa if issues.

QA Steps:
- open Dev UI -> Item Spawner
- select Slingshot; verify count cannot exceed 1
- select Slingshot Ammo; verify count caps at 99
- attempt to spawn 200 ammo via textbox; ensure only 99 added


------
https://chatgpt.com/codex/tasks/task_e_68abb7d506488322bd48d5884082315a