### PR TITLE
fix(resources): layer rock tops above player

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -118,6 +118,21 @@ export default function createResourceSystem(scene) {
             const blocking = !!def.blocking;
             trunk.setData('blocking', blocking);
 
+            if (blocking && def.tags?.includes('rock')) {
+                const frameW = trunk.width;
+                const frameH = trunk.height;
+                const topH = frameH * 0.5;
+                const top = scene.add
+                    .image(x, y, texKey)
+                    .setOrigin(originX, originY)
+                    .setScale(scale)
+                    .setDepth((scene.player?.depth ?? 900) + 2)
+                    .setCrop(0, 0, frameW, topH);
+                trunk.setCrop(0, topH, frameW, frameH - topH);
+                trunk.setData('topSprite', top);
+                trunk.once('destroy', () => top.destroy());
+            }
+
             if (def.tags?.includes('bush')) trunk.setData('bush', true);
 
             const bodyCfg = def.world?.body;


### PR DESCRIPTION
## Summary
- ensure player renders behind rock top halves but in front of bottoms

## Technical Approach
- systems/resourceSystem.js: crop rock sprites and draw a top overlay above player depth

## Performance
- overlay created once per rock spawn; no per-frame allocations

## Risks & Rollback
- rock sprites with unconventional shapes may crop oddly; revert commit to restore previous rendering

## QA Steps
- Launch game
- Move the player around rocks
- Verify the player appears in front of rock bases and behind rock tops


------
https://chatgpt.com/codex/tasks/task_e_68abbba77d188322aecb9aba86d042fc