### PR TITLE
fix(combat): scale bullet lifetime with timeScale

### DIFF
--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -233,9 +233,10 @@ export default function createCombatSystem(scene) {
         const v = scene.physics.velocityFromRotation(angle, speed);
         bullet.setVelocity(v.x, v.y);
         bullet.setRotation(angle);
+        const scale = DevTools.cheats.timeScale || 1;
         const lifetimeMs = Math.max(
             1,
-            Math.floor((travel / Math.max(1, speed)) * 1000),
+            Math.floor((travel / Math.max(1, speed)) * 1000 * scale),
         );
         scene.time.delayedCall(lifetimeMs, () => {
             if (bullet.active && bullet.destroy) bullet.destroy();


### PR DESCRIPTION
Summary:
- ensure ranged projectiles persist for their full travel distance when the game's time scale is slowed.

Technical Approach:
- systems/combatSystem.js (fireRangedWeapon): multiply projectile lifetime by DevTools.cheats.timeScale before scheduling destruction.

Performance:
- reuses existing projectile pooling with only lightweight math outside of per-frame loops.

Risks & Rollback:
- extremely large timeScale values may create long-lived projectiles; revert commit if misbehavior occurs.

QA Steps:
- enable a slow DevTools.cheats.timeScale (e.g., 0.5) and fire a ranged weapon; projectiles should reach full range instead of despawning early.
- reset timeScale to 1 and fire again; behavior should match pre-change lifetime.


------
https://chatgpt.com/codex/tasks/task_e_68abc0ce340c83229a421dac3ceccd71