### PR TITLE
fix: clear zombie spawn timer on day start

### DIFF
--- a/systems/dayNightSystem.js
+++ b/systems/dayNightSystem.js
@@ -13,6 +13,10 @@ export default function createDayNightSystem(scene) {
             scene.nightWaveTimer.remove(false);
             scene.nightWaveTimer = null;
         }
+        if (scene.spawnZombieTimer) {
+            scene.spawnZombieTimer.remove(false);
+            scene.spawnZombieTimer = null;
+        }
         scene.waveNumber = 0;
         scheduleDaySpawn();
         updateTimeUi();
@@ -35,6 +39,10 @@ export default function createDayNightSystem(scene) {
     function scheduleDaySpawn() {
         const dayCfg = WORLD_GEN.spawns.zombie.day;
         const delay = Phaser.Math.Between(dayCfg.minDelayMs, dayCfg.maxDelayMs);
+        if (scene.spawnZombieTimer) {
+            scene.spawnZombieTimer.remove(false);
+            scene.spawnZombieTimer = null;
+        }
         scene.spawnZombieTimer = scene.time.addEvent({
             delay,
             loop: false,


### PR DESCRIPTION
Summary:
- Clear lingering zombie spawn timer at day start to prevent stray spawns.
- Guard scheduleDaySpawn from external calls by removing existing timer before scheduling a new one.

Technical Approach:
- Updated startDay() and scheduleDaySpawn() in systems/dayNightSystem.js to remove existing spawnZombieTimer before proceeding.

Performance:
- Removes redundant timers without affecting per-frame allocations; work happens only on phase transitions.

Risks & Rollback:
- Low risk: timer removal could interfere with external timer management. Revert commit 12230d0 if issues arise.

QA Steps:
- `npm test`
- Start game, transition from night to day and verify no zombies spawn until new day timers fire.


------
https://chatgpt.com/codex/tasks/task_e_68abc1e56c708322b88b463df4177327