### PR TITLE
fix: ensure ranged projectile lifetime respects time scale

### DIFF
--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -236,7 +236,7 @@ export default function createCombatSystem(scene) {
         const scale = DevTools.cheats.timeScale || 1;
         const lifetimeMs = Math.max(
             1,
-            Math.floor((travel / Math.max(1, speed)) * 1000 * scale),
+            Math.floor((travel / Math.max(1, speed)) * 1000 / scale),
         );
         scene.time.delayedCall(lifetimeMs, () => {
             if (bullet.active && bullet.destroy) bullet.destroy();

--- a/test/systems/combatSystem.test.js
+++ b/test/systems/combatSystem.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import createCombatSystem from '../../systems/combatSystem.js';
+import DevTools from '../../systems/DevTools.js';
+
+globalThis.Phaser = {
+    Math: {
+        Clamp: (v, min, max) => Math.min(Math.max(v, min), max),
+        Linear: (start, end, t) => start + (end - start) * t,
+        Angle: {
+            Between: (x1, y1, x2, y2) => Math.atan2(y2 - y1, x2 - x1),
+        },
+    },
+};
+
+function createStubScene(callStore) {
+    const bullet = {
+        active: true,
+        data: {},
+        body: {
+            setAllowGravity() {},
+            setCircle() {},
+            setOffset() {},
+        },
+        setActive() { return this; },
+        setVisible() { return this; },
+        setDepth() { return this; },
+        setScale() { return this; },
+        setSize() { return this; },
+        setData(key, value) { this.data[key] = value; return this; },
+        getData(key) { return this.data[key]; },
+        setVelocity() { return this; },
+        setRotation() { return this; },
+        destroy() { this.destroyed = true; },
+    };
+    const scene = {
+        player: { x: 0, y: 0 },
+        bullets: { get: () => bullet },
+        physics: {
+            velocityFromRotation: (angle, speed) => ({
+                x: Math.cos(angle) * speed,
+                y: Math.sin(angle) * speed,
+            }),
+            add: {
+                collider() {},
+                existing() {},
+                image() { return bullet; },
+            },
+            world: {},
+        },
+        time: {
+            delayedCall(ms, cb) {
+                callStore.push(ms);
+                cb();
+            },
+        },
+        resources: {},
+        uiScene: {
+            inventory: {
+                getEquipped: () => ({ id: 'bow' }),
+                firstViableAmmoFor: () => ({ ammoId: 'rock', total: 1 }),
+                consumeAmmo() {},
+            },
+            events: { emit() {} },
+        },
+        hasStamina: () => true,
+        spendStamina() {},
+    };
+    scene.bullet = bullet;
+    return scene;
+}
+
+test('fireRangedWeapon lifetime respects time scale', () => {
+    const run = (scale) => {
+        DevTools.cheats.timeScale = scale;
+        const calls = [];
+        const scene = createStubScene(calls);
+        const combat = createCombatSystem(scene);
+        const pointer = { worldX: 100, worldY: 0 };
+        const wpn = { projectileSpeed: 100, minRange: 100, maxRange: 100 };
+        combat.fireRangedWeapon(pointer, wpn, 1);
+        return calls[0];
+    };
+
+    const slowLifetime = run(0.5);
+    assert.equal(slowLifetime, 2000);
+
+    const fastLifetime = run(2);
+    assert.equal(fastLifetime, 500);
+});


### PR DESCRIPTION
Summary:
- Adjust projectile lifetime to account for DevTools timeScale so projectiles travel full range under slow/fast modes.

Technical Approach:
- systems/combatSystem.js (fireRangedWeapon): divide travel time by cheat timeScale before scheduling bullet destruction.
- test/systems/combatSystem.test.js: add unit test verifying lifetime at time scales below and above 1.

Performance:
- Pure arithmetic; no additional allocations or per-frame work.

Risks & Rollback:
- Misinterpreting timeScale could cause bullets to persist too long or despawn early. Revert commit if issues arise.

QA Steps:
- `npm test`
- Set `DevTools.cheats.timeScale = 0.5` and fire a ranged weapon; bullet should reach full range.
- Set `DevTools.cheats.timeScale = 2` and fire a ranged weapon; bullet should again reach full range.

------
https://chatgpt.com/codex/tasks/task_e_68abc3545f6c832294abe14dccc13737