### PR TITLE
fix: raise tree hitbox bottoms by 10px

### DIFF
--- a/data/resourceDatabase.js
+++ b/data/resourceDatabase.js
@@ -355,7 +355,7 @@ export const RESOURCE_DB = {
       body: {
         kind: 'rect',
         width: 16,
-        height: 20,
+        height: 10,
         offsetX: 0,
         offsetY: -12,
         useScale: true,
@@ -391,7 +391,7 @@ export const RESOURCE_DB = {
       body: {
         kind: 'rect',
         width: 16,
-        height: 20,
+        height: 10,
         offsetX: 0,
         offsetY: -12,
         useScale: true,
@@ -427,7 +427,7 @@ export const RESOURCE_DB = {
       body: {
         kind: 'rect',
         width: 16,
-        height: 20,
+        height: 10,
         offsetX: 0,
         offsetY: -12,
         useScale: true,
@@ -463,7 +463,7 @@ export const RESOURCE_DB = {
       body: {
         kind: 'rect',
         width: 16,
-        height: 20,
+        height: 10,
         offsetX: 0,
         offsetY: -12,
         useScale: true,
@@ -499,7 +499,7 @@ export const RESOURCE_DB = {
       body: {
         kind: 'rect',
         width: 16,
-        height: 20,
+        height: 10,
         offsetX: 0,
         offsetY: -12,
         useScale: true,
@@ -535,7 +535,7 @@ export const RESOURCE_DB = {
       body: {
         kind: 'rect',
         width: 16,
-        height: 20,
+        height: 10,
         offsetX: 0,
         offsetY: -12,
         useScale: true,


### PR DESCRIPTION
## Summary
- raise tree resource hitbox bottoms by 10px to better match visuals

## Technical Approach
- reduce `world.body.height` for all tree entries in `data/resourceDatabase.js`

## Performance
- data-only change; no per-frame allocations or update math added

## Risks & Rollback
- tree collisions may feel off if heights are mis-tuned
- rollback by reverting the commit

## QA Steps
- `npm test`
- run the game and ensure player collides with trees slightly higher at the base


------
https://chatgpt.com/codex/tasks/task_e_68abc975af7883228ad6faf76a08ba5c