### PR TITLE
fix: shrink bush hitboxes by 10%

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -213,10 +213,11 @@ export default function createResourceSystem(scene) {
                         trunk.body.setImmovable(true);
                     } else {
                         if (trunk.getData('bush')) {
-                            const r = Math.min(
-                                trunk.displayWidth,
-                                trunk.displayHeight,
-                            ) * 0.5;
+                            const r =
+                                Math.min(
+                                    trunk.displayWidth,
+                                    trunk.displayHeight,
+                                ) * 0.45; // shrink hitbox by 10%
                             const ox = trunk.displayWidth * 0.5 - r;
                             const oy = trunk.displayHeight * 0.5 - r;
                             trunk.body.setCircle(r, ox, oy);


### PR DESCRIPTION
## Summary
- shrink default bush hitbox radius for more forgiving navigation

## Technical Approach
- adjust bush collider radius in `systems/resourceSystem.js`

## Performance
- change computed once during resource creation; no per-frame allocations

## Risks & Rollback
- smaller colliders could let players clip past dense foliage
- revert commit if collision issues arise

## QA Steps
- spawn bushes and verify collision radius feels ~10% smaller
- ensure bush slow effect still applies
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abcdef08888322a4d80cd55e2c8731