### PR TITLE
fix: match zombie depth to player for tree overlap

### DIFF
--- a/data/zombieDatabase.js
+++ b/data/zombieDatabase.js
@@ -7,7 +7,9 @@ const ZOMBIES = {
         name: 'Walker',
         textureKey: 'zombie',
         scale: 0.1,
-        depth: 2,
+        // Match player depth so zombies render under tree canopies when north
+        // of the trunk and over the trunk when south of it.
+        depth: 900,
 
         // Core stats
         health: 25,

--- a/test/systems/zombieDepth.test.js
+++ b/test/systems/zombieDepth.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import createCombatSystem from '../../systems/combatSystem.js';
+
+globalThis.Phaser = {
+    Math: {
+        Clamp: (v, min, max) => Math.min(Math.max(v, min), max),
+        Linear: (start, end, t) => start + (end - start) * t,
+        Angle: {
+            Between: (x1, y1, x2, y2) => Math.atan2(y2 - y1, x2 - x1),
+            Normalize: (angle) => angle,
+            DegToRad: (deg) => (deg * Math.PI) / 180,
+        },
+        Between: (min, max) => min + (max - min) * 0.5,
+        Distance: {
+            Squared: (x1, y1, x2, y2) => {
+                const dx = x2 - x1;
+                const dy = y2 - y1;
+                return dx * dx + dy * dy;
+            },
+        },
+    },
+};
+
+test('spawned zombies use player depth for tree overlap', () => {
+    const zombie = {
+        body: { setAllowGravity() {} },
+        setOrigin() { return this; },
+        setScale() { return this; },
+        setDepth(d) { this.depth = d; return this; },
+    };
+    const scene = {
+        zombies: { create: () => zombie },
+        physics: { add: { existing() {} } },
+    };
+    const combat = createCombatSystem(scene);
+    const z = combat.spawnZombie('walker', { x: 0, y: 0 });
+    assert.equal(z.depth, 900);
+});


### PR DESCRIPTION
## Summary
- match zombie render depth to the player's so trees overlay zombies when north and appear behind them when south
- add regression test for zombie depth

## Technical Approach
- set default zombie depth to 900 in `data/zombieDatabase.js`
- new `test/systems/zombieDepth.test.js` verifies spawnZombie depth

## Performance
- uses constant depth; no per-frame allocations

## Risks & Rollback
- zombie depth change may affect other layering (e.g., bullets); revert commit `b9eac0b` if issues arise

## QA Steps
- `npm test`
- spawn a zombie near a tree and move it above and below the trunk to confirm correct layering


------
https://chatgpt.com/codex/tasks/task_e_68abd13361b883228e3ce071a9325afe