### PR TITLE
fix(ui): darken game over screen

### DIFF
--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -106,7 +106,13 @@ export default function createCombatSystem(scene) {
             scene._isSwinging = false;
             if (scene.gameOverText?.destroy) scene.gameOverText.destroy();
             if (scene.respawnPrompt?.destroy) scene.respawnPrompt.destroy();
+            if (scene.gameOverOverlay?.destroy) scene.gameOverOverlay.destroy();
             const cam = scene.cameras.main;
+            scene.gameOverOverlay = scene.add
+                .rectangle(0, 0, cam.width, cam.height, 0x000000, 0.5)
+                .setOrigin(0, 0)
+                .setScrollFactor(0)
+                .setDepth(999);
             const cx = cam.worldView.x + cam.worldView.width * 0.5;
             const cy = cam.worldView.y + cam.worldView.height * 0.5;
             scene.gameOverText = scene.add


### PR DESCRIPTION
Summary:
- Darken screen on game over with 50% black overlay.

Technical Approach:
- Added semi-transparent rectangle behind game over text in `combatSystem.js`.

Performance:
- Overlay created once at game over; no per-frame allocations.

Risks & Rollback:
- Relies on camera dimensions; revert commit if overlay misbehaves.

QA Steps:
- Die in-game to trigger game over.
- Verify screen darkens while GAME OVER text remains visible.
- Press SPACE to respawn and ensure overlay clears.


------
https://chatgpt.com/codex/tasks/task_e_68abd445e508832280e0b6d6743b066e