### PR TITLE
feat: tighten resource clusters and remove spawn padding

### DIFF
--- a/data/worldGenConfig.js
+++ b/data/worldGenConfig.js
@@ -35,7 +35,8 @@ export const WORLD_GEN = {
         rocks: {
           maxActive: 10,
           minSpacing: 100,  // pixels between rock centers
-          clusterMax: 3,
+          clusterMin: 3,
+          clusterMax: 6,
           respawnDelayMs: { min: 5000, max: 7000 },
           variants: [
             { id: RESOURCE_IDS.ROCK1A, weight: 40 }, // collectible, non-blocking
@@ -58,7 +59,8 @@ export const WORLD_GEN = {
         trees: {
           maxActive: 10,
           minSpacing: 100,
-          clusterMax: 3,
+          clusterMin: 3,
+          clusterMax: 6,
           variants: [
             { id: RESOURCE_IDS.TREE1A, weight: 20 },
             { id: RESOURCE_IDS.TREE1B, weight: 10 },
@@ -72,7 +74,8 @@ export const WORLD_GEN = {
         bushes: {
           maxActive: 15,
           minSpacing: 50,
-          clusterMax: 3,
+          clusterMin: 3,
+          clusterMax: 6,
           variants: [
             { id: RESOURCE_IDS.BUSH1A, weight: 20 },
             { id: RESOURCE_IDS.BUSH1B, weight: 10 },

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -69,16 +69,16 @@ export default function createResourceSystem(scene) {
         const minSpacing = groupCfg.minSpacing ?? 48;
         const respawnMin = groupCfg.respawnDelayMs?.min ?? 5000;
         const respawnMax = groupCfg.respawnDelayMs?.max ?? 7000;
-        const clusterMax = groupCfg.clusterMax ?? 3;
-        const clusterRadius = groupCfg.clusterRadius ?? minSpacing * 2;
+        const clusterMin = groupCfg.clusterMin ?? 3;
+        const clusterMax = groupCfg.clusterMax ?? 6;
         const totalWeight = variants.reduce((s, v) => s + (v.weight || 0), 0);
 
         const w = scene.sys.game.config.width;
         const h = scene.sys.game.config.height;
-        const minX = 100,
-            maxX = w - 100,
-            minY = 100,
-            maxY = h - 100;
+        const minX = 0,
+            maxX = w,
+            minY = 0,
+            maxY = h;
 
         const tooClose = (x, y, w, h) => {
             const children = scene.resources.getChildren();
@@ -416,7 +416,9 @@ export default function createResourceSystem(scene) {
             createResourceAt(id, def, x, y);
             let spawned = 1;
 
-            const clusterCount = Phaser.Math.Between(1, clusterMax);
+            const clusterCount = Phaser.Math.Between(clusterMin, clusterMax);
+            const radius =
+                groupCfg.clusterRadius ?? Math.max(width, height) * 1.1;
             for (
                 let i = 1;
                 i < clusterCount && scene.resources.countActive(true) < maxActive;
@@ -426,10 +428,9 @@ export default function createResourceSystem(scene) {
                     y2,
                     t2 = 10;
                 do {
-                    x2 =
-                        x + Phaser.Math.Between(-clusterRadius, clusterRadius);
-                    y2 =
-                        y + Phaser.Math.Between(-clusterRadius, clusterRadius);
+                    const ang = Phaser.Math.FloatBetween(0, Math.PI * 2);
+                    x2 = x + Math.cos(ang) * radius;
+                    y2 = y + Math.sin(ang) * radius;
                     t2--;
                 } while (t2 > 0 && tooClose(x2, y2, width, height));
                 if (t2 <= 0) continue;


### PR DESCRIPTION
Summary:
- Allow resources to spawn across the full visible screen without edge padding.
- Spawn tighter resource clusters for clearer groupings.

Technical Approach:
- systems/resourceSystem.js: remove 100px spawn padding, require 3-6 items per cluster, and place cluster members at near-touching radius.
- data/worldGenConfig.js: define clusterMin/clusterMax for rocks, trees, and bushes.

Performance:
- Cluster math uses simple random calculations and reuses existing objects; no per-frame allocations.

Risks & Rollback:
- Resources may spawn partially off-screen; revert commit 73f5fd5 to restore previous padding and clustering.

QA Steps:
- Start the game and observe resources spawning up to screen edges.
- Verify each resource cluster contains 3-6 items positioned closely together.


------
https://chatgpt.com/codex/tasks/task_e_68abd7e370f883228a826b324f63e64e