### PR TITLE
feat: drag-drop inventory items to ground

### DIFF
--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -184,6 +184,12 @@ export default class UIScene extends Phaser.Scene {
             .setAlpha(INVENTORY_CONFIG.panelAlpha);
         this.inventoryPanel.add(panelBg);
         this.panelBg = panelBg;
+        this._inventoryBounds = new Phaser.Geom.Rectangle(
+            panelX,
+            panelY,
+            panelW,
+            panelH,
+        );
 
         // Visual dividers (cosmetic)
         const third = panelW / 3;
@@ -296,6 +302,20 @@ export default class UIScene extends Phaser.Scene {
                     }
                     this.inventoryPanel.setVisible(false);
                 }
+            }
+        });
+
+        this.input.on('pointerup', (pointer) => {
+            if (!this.inventoryPanel.visible) return;
+            if (!this.dragCarry) return;
+            const x = pointer.worldX;
+            const y = pointer.worldY;
+            if (!Phaser.Geom.Rectangle.Contains(this._inventoryBounds, x, y)) {
+                const main = this.scene.get('MainScene');
+                if (main && typeof main.dropItemStack === 'function') {
+                    main.dropItemStack(this.dragCarry.id, this.dragCarry.count);
+                }
+                this.#clearCarry();
             }
         });
 


### PR DESCRIPTION
Summary:
- Allow dropping inventory stacks by dragging them outside the inventory panel.
- Dropped items spawn at the player with a shadow and auto-despawn after one day.

Technical Approach:
- Added `dropItemStack` in `MainScene` to create world item sprites with shadows and timers.
- Tracked inventory panel bounds and hooked `pointerup` in `UIScene` to trigger drops when releasing outside the panel.

Performance:
- Dropped items allocate sprites and timers once and clean up timers on destroy.
- No per-frame allocations added; update loop untouched.

Risks & Rollback:
- Partial pickups leave remaining stack on ground; ensure inventory space before dropping.
- Revert commit `682ae60` to rollback.

QA Steps:
- Open inventory and drag an item outside the panel, release to drop.
- Verify a small sprite with shadow appears at player position.
- Right-click near the dropped item to pick it up.
- Observe item disappears if left untouched for ~4 minutes.


------
https://chatgpt.com/codex/tasks/task_e_68acd9c73508832289ac52fc61294190