### PR TITLE
fix: sync cooldowns with game speed

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -261,9 +261,6 @@ export default class MainScene extends Phaser.Scene {
             const now = DevTools.now(this);
             const diff = now - (this._pauseStart || now);
             if (diff > 0) {
-                if (this._nextRangedReadyTime) this._nextRangedReadyTime += diff;
-                if (this._lastSwingEndTime) this._lastSwingEndTime += diff;
-                if (this.isCharging) this.chargeStart += diff;
                 if (this._lastStaminaSpendTime) this._lastStaminaSpendTime += diff;
             }
             this._pauseStart = 0;
@@ -429,6 +426,7 @@ export default class MainScene extends Phaser.Scene {
                     ),
                 )
             ) {
+                DevTools.resetToDefaults(this);
                 this.scene.stop('UIScene');
                 this.scene.restart();
             }
@@ -498,9 +496,8 @@ export default class MainScene extends Phaser.Scene {
         this.regenStamina(delta);
 
         // Zombie pursuit (simple: slide → then stun → then chase)
+        const now = this.time.now;
         this.zombies.getChildren().forEach((zombie) => {
-            const now = DevTools.now(this);
-
             const inKnockback = (zombie.knockbackUntil || 0) > now;
             const stunned = (zombie.stunUntil || 0) > now && !inKnockback; // stun begins after slide
 
@@ -731,9 +728,8 @@ export default class MainScene extends Phaser.Scene {
         if (!wpnDef || wpnDef.canCharge !== true) return;
 
         // Raw 0..1 charge based on time held
-        const scale = DevTools.cheats.timeScale || 1;
         const heldMs = Phaser.Math.Clamp(
-            (DevTools.now(this) - this.chargeStart) * scale,
+            this.time.now - this.chargeStart,
             0,
             this.chargeMaxMs,
         );

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -79,7 +79,7 @@ export default function createCombatSystem(scene) {
     function handlePlayerZombieCollision(player, zombie) {
         if (scene.isGameOver) return;
         if (DevTools?.isPlayerInvisible?.() === true) return;
-        const now = DevTools.now(scene) | 0;
+        const now = scene.time.now | 0;
         const hitCdMs = 500;
         if (!zombie.lastHitTime) zombie.lastHitTime = 0;
         if (now - zombie.lastHitTime < hitCdMs) return;
@@ -267,12 +267,10 @@ export default function createCombatSystem(scene) {
                 ? Math.floor(baseCd * st.lowCooldownMultiplier)
                 : baseCd;
         if (!DevTools.cheats.noCooldown && cdMs > 0) {
-            const scale = DevTools.cheats.timeScale || 1;
-            const dur = Math.floor(cdMs / scale);
-            scene._nextRangedReadyTime = DevTools.now(scene) + dur;
+            scene._nextRangedReadyTime = scene.time.now + cdMs;
             scene.uiScene?.events?.emit('weapon:cooldownStart', {
                 itemId: equipped.id,
-                durationMs: dur,
+                durationMs: cdMs,
             });
         }
         scene.uiScene?.events?.emit('weapon:chargeEnd');
@@ -295,7 +293,7 @@ export default function createCombatSystem(scene) {
         if (scene._isSwinging) return;
         const effectiveCooldownMs =
             scene._nextSwingCooldownMs ?? baseCooldownMs;
-        const now = DevTools.now(scene);
+        const now = scene.time.now;
         if (now - (scene._lastSwingEndTime || 0) < effectiveCooldownMs) return;
         const st = wpn?.stamina;
         let lowStamina = false;
@@ -314,9 +312,8 @@ export default function createCombatSystem(scene) {
         }
         const cooldownMult =
             lowStamina && st ? (st.cooldownMultiplier ?? 6) : 1;
-        const scale = DevTools.cheats.timeScale || 1;
         scene._nextSwingCooldownMs = Math.floor(
-            (baseCooldownMs * cooldownMult) / scale,
+            baseCooldownMs * cooldownMult,
         );
         const canCharge = wpn?.canCharge === true;
         let charge = canCharge
@@ -383,7 +380,7 @@ export default function createCombatSystem(scene) {
         cone.setData('aimAngle', startRot);
         cone.setData('coneHalfRad', halfArc);
         cone.setData('maxRange', range);
-        cone.setData('swingStartMs', DevTools.now(scene) | 0);
+        cone.setData('swingStartMs', scene.time.now | 0);
         cone.setData('swingDurationMs', swingDurationMs | 0);
         scene._isSwinging = true;
         const swing = { t: 0 };
@@ -406,7 +403,7 @@ export default function createCombatSystem(scene) {
             },
             onComplete: () => {
                 scene._isSwinging = false;
-                scene._lastSwingEndTime = DevTools.now(scene);
+                scene._lastSwingEndTime = scene.time.now;
                 if (scene.batSprite) {
                     scene.batSprite.destroy();
                     scene.batSprite = null;
@@ -559,7 +556,7 @@ export default function createCombatSystem(scene) {
         const vx = (dx / len) * impulse;
         const vy = (dy / len) * impulse;
         zombie.setVelocity(vx, vy);
-        const now = DevTools.now(scene) | 0;
+        const now = scene.time.now | 0;
         zombie.knockbackUntil = now + 120;
         if (baseKb >= (zombie.staggerThreshold || 99999)) {
             zombie.stunUntil = now + (zombie.stunDurationMs || 300);

--- a/systems/inputSystem.js
+++ b/systems/inputSystem.js
@@ -17,7 +17,7 @@ export default function createInputSystem(scene) {
 
         if (cat === 'melee' && equipped.id === 'crude_bat') {
             const wpn = def.weapon || {};
-            const now = DevTools.now(scene);
+            const now = scene.time.now;
             const baseCd = wpn?.swingCooldownMs ?? 80;
             const effectiveCd = scene._nextSwingCooldownMs ?? baseCd;
             const lastEnd = scene._lastSwingEndTime || 0;
@@ -41,7 +41,7 @@ export default function createInputSystem(scene) {
 
         if (cat === 'ranged' && equipped.id === 'slingshot') {
             const wpn = def.weapon || {};
-            const now = DevTools.now(scene);
+            const now = scene.time.now;
             const fireCd = wpn?.fireCooldownMs ?? 0;
             if (
                 !DevTools.cheats.noCooldown &&
@@ -75,9 +75,8 @@ export default function createInputSystem(scene) {
             return;
         }
 
-        const scale = DevTools.cheats.timeScale || 1;
         const heldMs = Phaser.Math.Clamp(
-            (DevTools.now(scene) - scene.chargeStart) * scale,
+            scene.time.now - scene.chargeStart,
             0,
             scene.chargeMaxMs,
         );

--- a/test/systems/combatSystem.test.js
+++ b/test/systems/combatSystem.test.js
@@ -50,6 +50,7 @@ function createStubScene(callStore) {
             world: {},
         },
         time: {
+            now: 0,
             delayedCall(ms, cb) {
                 callStore.push(ms);
                 cb();


### PR DESCRIPTION
## Summary
- ensure weapon and zombie hit cooldowns reflect current game speed
- reset DevTools cheats when respawning

## Technical Approach
- swap DevTools.now for scene.time.now across combatSystem, inputSystem, and MainScene to tie timers to scene time
- compute cooldown end times from scene.time.now without manual scaling
- call DevTools.resetToDefaults on respawn

## Performance
- time lookups hoisted to avoid per-frame allocations
- no additional objects created in update loops

## Risks & Rollback
- relies on Phaser's scene.time behavior; if incorrect, timers may drift
- rollback by restoring previous DevTools.now usage and removing respawn reset

## QA Steps
- set game speed to 0.5, start a melee attack, change speed to 2x mid-cooldown; attack should become ready sooner
- let a zombie hit the player, then adjust game speed; subsequent hits should respect new speed
- toggle DevTools cheats, die, respawn with SPACE; all cheats should return to defaults


------
https://chatgpt.com/codex/tasks/task_e_68acda10d02c8322a3de15c13d51f097