### PR TITLE
fix(resources): map tree10 textures to existing assets

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -78,9 +78,9 @@ export default class MainScene extends Phaser.Scene {
         this.load.image('tree2A', 'assets/resources/trees/tree2A.png');
         this.load.image('tree2B', 'assets/resources/trees/tree2B.png');
         this.load.image('tree2C', 'assets/resources/trees/tree2C.png');
-        this.load.image('tree10A', 'assets/resources/trees/tree10A.png');
-        this.load.image('tree10B', 'assets/resources/trees/tree10B.png');
-        this.load.image('tree10C', 'assets/resources/trees/tree10C.png');
+        this.load.image('tree10A', 'assets/resources/trees/tree11A.png');
+        this.load.image('tree10B', 'assets/resources/trees/tree11B.png');
+        this.load.image('tree10C', 'assets/resources/trees/tree11C.png');
         // bushes
         this.load.image('bush1A', 'assets/resources/bushes/bush1A.png');
         this.load.image('bush1B', 'assets/resources/bushes/bush1B.png');


### PR DESCRIPTION
## Summary
- resolve missing tree10 texture 404s by loading available tree11 images under tree10 keys

## Technical Approach
- updated `preload()` in `scenes/MainScene.js` to load `tree11A-C.png` while keeping tree10 texture keys

## Performance
- no runtime impact; only adjusts asset preload paths

## Risks & Rollback
- if true tree10 textures are added later, these mappings may need revision
- rollback by reverting commit `c522d40`

## QA Steps
- `npm test`
- run game and ensure no 404 errors for `tree10A-C.png` in browser console


------
https://chatgpt.com/codex/tasks/task_e_68acdfdad9ec8322b04801fafd820e0a