### PR TITLE
fix: game speed-aware cooldowns and respawn reset

### DIFF
--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -37,9 +37,9 @@ export default class UIScene extends Phaser.Scene {
 
         const main = this.scene.get('MainScene');
         if (main) {
-            const onPause = () => { this._pauseStart = DevTools.now(this); };
+            const onPause = () => { this._pauseStart = this.time.now; };
             const onResume = () => {
-                const now = DevTools.now(this);
+                const now = this.time.now;
                 const diff = now - (this._pauseStart || now);
                 if (diff > 0) {
                     for (const cd of this._activeCooldowns.values()) {
@@ -413,7 +413,7 @@ export default class UIScene extends Phaser.Scene {
         // NEW: cooldown overlays (e.g., bat swings)
         this.events.on('weapon:cooldownStart', ({ itemId, durationMs }) => {
             if (!itemId || !durationMs || durationMs <= 0) return;
-            const now = DevTools.now(this);
+            const now = this.time.now;
             this._activeCooldowns.set(itemId, { start: now, end: now + durationMs });
             this.#syncCooldownOverlays();
         });
@@ -780,7 +780,7 @@ export default class UIScene extends Phaser.Scene {
     // Create/ensure overlays for any slots showing items currently on cooldown,
     // and remove overlays that no longer match or have expired.
     #syncCooldownOverlays() {
-        const now = this._pauseStart || DevTools.now(this);
+        const now = this._pauseStart || this.time.now;
 
         // Remove expired item cooldowns
         for (const [itemId, cd] of this._activeCooldowns) {
@@ -884,7 +884,7 @@ export default class UIScene extends Phaser.Scene {
     #updateCooldownOverlays() {
         if (this._slotOverlays.length === 0) return;
 
-        const now = this._pauseStart || DevTools.now(this);
+        const now = this._pauseStart || this.time.now;
         for (let i = this._slotOverlays.length - 1; i >= 0; i--) {
             const o = this._slotOverlays[i];
             const cd = this._activeCooldowns.get(o.itemId);

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -80,7 +80,8 @@ export default function createCombatSystem(scene) {
         if (scene.isGameOver) return;
         if (DevTools?.isPlayerInvisible?.() === true) return;
         const now = scene.time.now | 0;
-        const hitCdMs = 500;
+        const scale = DevTools.cheats.timeScale || 1;
+        const hitCdMs = 500 / scale;
         if (!zombie.lastHitTime) zombie.lastHitTime = 0;
         if (now - zombie.lastHitTime < hitCdMs) return;
         zombie.lastHitTime = now;
@@ -89,9 +90,6 @@ export default function createCombatSystem(scene) {
         scene.health = Math.max(0, (scene.health | 0) - damage);
         scene.uiScene?.updateHealth?.(scene.health);
         if (scene.health <= 0) {
-            try {
-                DevTools.resetToDefaults(scene);
-            } catch {}
             scene.isGameOver = true;
             scene.physics.world.isPaused = true;
             try {


### PR DESCRIPTION
Summary:
- Sync weapon cooldown overlays and zombie hit delays with game speed changes.
- Reset dev tool cheats when respawning.

Technical Approach:
- scenes/UIScene.js uses scene time for cooldown bookkeeping and overlay updates.
- systems/combatSystem.js scales zombie hit cooldown by current timeScale and drops death-time reset.

Performance:
- Pure arithmetic in update paths; no new allocations or timers.

Risks & Rollback:
- Time scaling interactions across scenes could still desync; revert commit e474103 if issues arise.

QA Steps:
- Adjust game speed while a weapon cooldown runs; overlay and weapon readiness should speed up or slow down accordingly.
- Increase game speed and collide with a zombie; collision damage rate scales with speed.
- Toggle dev cheats, die, then respawn; cheats return to defaults after respawn.


------
https://chatgpt.com/codex/tasks/task_e_68acebe28fb88322b0ed87ffcd017d88