### PR TITLE
fix(inventory): remove default starting items

### DIFF
--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -374,10 +374,7 @@ export default class UIScene extends Phaser.Scene {
             }
         });
 
-        // Puting items in inventory
-        this.inventory.addItem('slingshot_rock', 7);
-        this.inventory.hotbar[0] = { id: 'slingshot', count: 1 };
-        this.inventory.hotbar[1] = { id: 'crude_bat', count: 1 };
+        // Initialize inventory state
         this.events.emit('inv:changed');
 
         // React to model changes


### PR DESCRIPTION
Summary:
- Remove hardcoded slingshot, crude bat, and ammo from starting inventory so players begin empty.

Technical Approach:
- scenes/UIScene.js: dropped addItem('slingshot_rock', 7) and hotbar assignments; emit inv:changed to initialize UI.

Performance:
- No per-frame allocations; change only occurs on scene creation.

Risks & Rollback:
- Players now have no weapon at start; ensure gameplay expects this. Roll back by reverting commit 7aff448.

QA Steps:
- `npm test`
- Start the game and verify inventory/hotbar are empty.
- Pick up an item and confirm it appears in inventory and hotbar.


------
https://chatgpt.com/codex/tasks/task_e_68acf1945508832295afa1b6e14536c9