### PR TITLE
feat: add item drops for small rock resources

### DIFF
--- a/data/itemDatabase.js
+++ b/data/itemDatabase.js
@@ -6,6 +6,9 @@ export const ITEM_IDS = {
   SLINGSHOT: 'slingshot',
   SLINGSHOT_ROCK: 'slingshot_rock',
   CRUDE_BAT: 'crude_bat',
+  ROCK1A: 'rock1A',
+  ROCK2A: 'rock2A',
+  ROCK5A: 'rock5A',
 };
 
 export const ITEM_TYPES = {
@@ -178,9 +181,62 @@ export const ITEM_DB = {
     meta: { rarity: 'common' },
   },
 
+  //-------------------------------
+  // Resources
+  //-------------------------------
+
+  [ITEM_IDS.ROCK1A]: {
+    id: ITEM_IDS.ROCK1A,
+    name: 'Small Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: true,
+    maxStack: 99,
+
+    icon: { textureKey: 'rock1A', scale: 1.0, ox: 0, oy: 0 },
+    world: { textureKey: 'rock1A', scale: .65 },
+
+    sounds: { pickup: 'sfx_pickup_small' },
+
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'common' },
+  },
+
+  [ITEM_IDS.ROCK2A]: {
+    id: ITEM_IDS.ROCK2A,
+    name: 'Small Grassy Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: true,
+    maxStack: 99,
+
+    icon: { textureKey: 'rock2A', scale: 1.0, ox: 0, oy: 0 },
+    world: { textureKey: 'rock2A', scale: .65 },
+
+    sounds: { pickup: 'sfx_pickup_small' },
+
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'common' },
+  },
+
+  [ITEM_IDS.ROCK5A]: {
+    id: ITEM_IDS.ROCK5A,
+    name: 'Small Marble Rock',
+    type: ITEM_TYPES.RESOURCE,
+    stackable: true,
+    maxStack: 99,
+
+    icon: { textureKey: 'rock5A', scale: 1.0, ox: 0, oy: 0 },
+    world: { textureKey: 'rock5A', scale: .65 },
+
+    sounds: { pickup: 'sfx_pickup_small' },
+
+    tags: ['resource', 'rock'],
+    meta: { rarity: 'common' },
+  },
+
 };
 
 export const GROUPS = {
   weapons: [ITEM_IDS.SLINGSHOT, ITEM_IDS.CRUDE_BAT],
   ammo: [ITEM_IDS.SLINGSHOT_ROCK ],
+  resources: [ITEM_IDS.ROCK1A, ITEM_IDS.ROCK2A, ITEM_IDS.ROCK5A],
 };

--- a/data/resourceDatabase.js
+++ b/data/resourceDatabase.js
@@ -59,7 +59,7 @@ export const RESOURCE_DB = {
     world: { textureKey: 'rock1A', scale: .65 },
     collectible: true,          // custom flag for pickup
     blocking: false,            // walk-through
-    givesItem: ITEM_IDS.SLINGSHOT_ROCK,
+    givesItem: ITEM_IDS.ROCK1A,
     giveAmount: 1,
     depth: 1,
     tags: ['resource', 'rock'],
@@ -157,7 +157,7 @@ export const RESOURCE_DB = {
     world: { textureKey: 'rock2A', scale: .65 },
     collectible: true,          // custom flag for pickup
     blocking: false,            // walk-through
-    givesItem: ITEM_IDS.SLINGSHOT_ROCK,
+    givesItem: ITEM_IDS.ROCK2A,
     giveAmount: 1,
     depth: 1,
     tags: ['resource', 'rock'],
@@ -255,7 +255,7 @@ export const RESOURCE_DB = {
     world: { textureKey: 'rock5A', scale: .65 },
     collectible: true,          // custom flag for pickup
     blocking: false,            // walk-through
-    givesItem: ITEM_IDS.SLINGSHOT_ROCK,
+    givesItem: ITEM_IDS.ROCK5A,
     giveAmount: 1,
     depth: 1,
     tags: ['resource', 'rock'],


### PR DESCRIPTION
Summary:
- Add inventory items for small rock variants and update resources to drop them.

Technical Approach:
- data/itemDatabase.js: define ROCK1A, ROCK2A, ROCK5A items and group them under resources.
- data/resourceDatabase.js: change rock1A/2A/5A resources to grant their respective items on pickup.

Performance:
- Data-only change; no per-frame allocations.

Risks & Rollback:
- Incorrect item IDs could break resource drops; revert commit 50fe9ef if issues arise.

QA Steps:
- `npm test`
- Launch game and right-click rock1A, rock2A, rock5A resources to see items added to inventory instead of slingshot ammo.


------
https://chatgpt.com/codex/tasks/task_e_68acf59db2908322aab6d5bbf15fd710