### PR TITLE
fix(dev-ui): expand dev menu button hitboxes

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -292,14 +292,14 @@ export default class DevUIScene extends Phaser.Scene {
     }
 
     _makeButton(x, y, w, h, text, onClick, depth = 1, fillColor = UI.btnColor) {
-        const r = this.add.rectangle(x, y, w, h, fillColor, 1).setOrigin(0, 0).setDepth(depth).setInteractive({ useHandCursor: true });
-        const t = this.add.text(x + 8, y + 6, text, UI.font).setDepth(depth + 1);
-        r.on('pointerover', () => r.setFillStyle(UI.btnHover, 1));
-        r.on('pointerout',  () => r.setFillStyle(fillColor, 1));
-        r.on('pointerdown', () => onClick && onClick());
-        const c = this.add.container(0, 0, [r, t]).setDepth(depth);
+        const r = this.add.rectangle(0, 0, w, h, fillColor, 1).setOrigin(0, 0).setDepth(depth);
+        const t = this.add.text(8, 6, text, UI.font).setDepth(depth + 1);
+        const c = this.add.container(x, y, [r, t]).setDepth(depth);
         c.setSize(w, h);
-        c.setInteractive(new Phaser.Geom.Rectangle(x, y, w, h), Phaser.Geom.Rectangle.Contains);
+        c.setInteractive(new Phaser.Geom.Rectangle(0, 0, w, h), Phaser.Geom.Rectangle.Contains);
+        c.on('pointerover', () => r.setFillStyle(UI.btnHover, 1));
+        c.on('pointerout', () => r.setFillStyle(fillColor, 1));
+        c.on('pointerdown', () => onClick && onClick());
         c._rect = r;
         return c;
     }


### PR DESCRIPTION
## Summary
- ensure dev menu button hitboxes match their visual size

## Technical Approach
- refactor `scenes/DevUIScene.js` `_makeButton` to position buttons via container with (0,0) hit area

## Performance
- UI-only change; no per-frame allocations added

## Risks & Rollback
- affects dev menu buttons; revert commit if interactions regress

## QA Steps
- Open dev menu
- Click plus buttons; entire button area should respond


------
https://chatgpt.com/codex/tasks/task_e_68acf6a5e92c832281dc39a51471b70b