### PR TITLE
fix: ensure auto pickup detects hovered items

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -457,9 +457,9 @@ export default class MainScene extends Phaser.Scene {
         }
         const pointer = this.input.activePointer;
         const hits = this.input.manager.hitTest(
-            pointer.x,
-            pointer.y,
+            pointer,
             this.droppedItems.getChildren(),
+            this.cameras.main,
         );
         for (let i = 0; i < hits.length; i++) {
             const item = hits[i];


### PR DESCRIPTION
Summary:
- Fix auto pickup failing when holding left click by using the proper InputManager.hitTest signature.

Technical Approach:
- scenes/MainScene.js: _attemptAutoPickup passes the active pointer and main camera to hitTest, allowing dropped items under the cursor to be detected.

Performance:
- No per-frame allocations added; auto pickup still checks at 200ms intervals.

Risks & Rollback:
- If hitTest behavior differs across Phaser versions, auto pickup might mis-detect items. Revert commit 2351b9c if issues arise.

QA Steps:
- Start the game.
- Drop or find an item on the ground.
- Hover the cursor over the item and hold left click for at least 2 seconds without charging a weapon.
- Verify the item is automatically picked up.


------
https://chatgpt.com/codex/tasks/task_e_68acf74b14708322a2f2449181cd70c8