### PR TITLE
fix: day-night cycle respects game speed

### DIFF
--- a/systems/dayNightSystem.js
+++ b/systems/dayNightSystem.js
@@ -143,7 +143,9 @@ export default function createDayNightSystem(scene) {
 
     // ----- Tick -----
     function tick(delta) {
-        scene._phaseElapsedMs = (scene._phaseElapsedMs || 0) + (delta | 0);
+        const scale = DevTools.cheats.timeScale || 1;
+        scene._phaseElapsedMs =
+            (scene._phaseElapsedMs || 0) + ((delta * scale) | 0);
         if (getPhaseElapsed() >= getPhaseDuration()) {
             if (scene.phase === 'day') {
                 startNight();

--- a/test/systems/dayNightSystem.test.js
+++ b/test/systems/dayNightSystem.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import createDayNightSystem from '../../systems/dayNightSystem.js';
+import DevTools from '../../systems/DevTools.js';
+
+globalThis.Phaser = {
+    Math: {
+        Linear: (start, end, t) => start + (end - start) * t,
+        Clamp: (v, min, max) => Math.min(Math.max(v, min), max),
+    },
+};
+
+test('tick scales day-night progression with time scale', () => {
+    const scene = {
+        phase: 'day',
+        dayIndex: 1,
+        nightOverlay: { setAlpha() {} },
+    };
+    const system = createDayNightSystem(scene);
+
+    DevTools.cheats.timeScale = 1;
+    system.tick(100);
+    assert.equal(scene._phaseElapsedMs, 100);
+
+    DevTools.cheats.timeScale = 2;
+    system.tick(100);
+    assert.equal(scene._phaseElapsedMs, 300);
+
+    DevTools.cheats.timeScale = 1;
+});
+


### PR DESCRIPTION
## Summary
- make day-night cycle progression obey game speed setting
- add test covering time-scale effect

## Technical Approach
- scale day-night tick delta by `DevTools.cheats.timeScale`
- created `test/systems/dayNightSystem.test.js`

## Performance
- per-frame tick uses simple multiplication; no allocations introduced

## Risks & Rollback
- low: only affects day-night timer; revert commit if unexpected behavior

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf94207888322952862e1e320f882