### PR TITLE
fix: auto-pickup collects resources after charging

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -45,6 +45,7 @@ export default class MainScene extends Phaser.Scene {
         this._autoPickupTimer = null;
         this._autoPickupEvent = null;
         this._autoPickupActive = false;
+        this._autoPickupPointer = { rightButtonDown: () => true };
     }
 
     preload() {
@@ -464,6 +465,17 @@ export default class MainScene extends Phaser.Scene {
         for (let i = 0; i < hits.length; i++) {
             const item = hits[i];
             if (this._pickupItem(item)) break;
+        }
+
+        const resourceHits = this.input.manager.hitTest(
+            pointer,
+            this.resources.getChildren(),
+            this.cameras.main,
+        );
+        for (let i = 0; i < resourceHits.length; i++) {
+            const res = resourceHits[i];
+            res.emit?.('pointerdown', this._autoPickupPointer);
+            if (!res.active) break;
         }
     }
 


### PR DESCRIPTION
## Summary
- enable charged auto-pickup to grab resources when the cursor moves over them

## Technical Approach
- add reusable right-click pointer stub
- extend `_attemptAutoPickup` in `scenes/MainScene` to hit test resource sprites and emit their pickup handler

## Performance
- reuses a single stub pointer; hit tests only run while auto-pickup is active to avoid per-frame allocations

## Risks & Rollback
- if auto-pickup misfires on non-collectible resources, revert commit 34156f8

## QA Steps
- Hold left mouse button for 2s without targeting anything
- Move cursor over a nearby collectible resource
- Verify the resource is picked up automatically

------
https://chatgpt.com/codex/tasks/task_e_68acf8ec3ac88322a8689eba192743ab