### PR TITLE
fix: enforce pointer overlap and player range for auto-pickup

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -456,25 +456,35 @@ export default class MainScene extends Phaser.Scene {
             this._cancelAutoPickup();
             return;
         }
-        const pointer = this.input.activePointer;
-        const hits = this.input.manager.hitTest(
-            pointer,
-            this.droppedItems.getChildren(),
-            this.cameras.main,
-        );
-        for (let i = 0; i < hits.length; i++) {
-            const item = hits[i];
+        const ptr = this.input.activePointer;
+        const px = ptr.worldX;
+        const py = ptr.worldY;
+        const pickupRange = 40;
+        const pickupRangeSq = pickupRange * pickupRange;
+        const items = this.droppedItems.getChildren();
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (!item.active) continue;
+            if (!Phaser.Geom.Rectangle.Contains(item.getBounds(), px, py))
+                continue;
+            const dx = this.player.x - item.x;
+            const dy = this.player.y - item.y;
+            const d2 = dx * dx + dy * dy;
+            if (d2 > pickupRangeSq) continue;
             if (this._pickupItem(item)) break;
         }
 
-        const resourceHits = this.input.manager.hitTest(
-            pointer,
-            this.resources.getChildren(),
-            this.cameras.main,
-        );
-        for (let i = 0; i < resourceHits.length; i++) {
-            const res = resourceHits[i];
-            res.emit?.('pointerdown', this._autoPickupPointer);
+        const resources = this.resources.getChildren();
+        for (let i = 0; i < resources.length; i++) {
+            const res = resources[i];
+            if (!res.active) continue;
+            if (!Phaser.Geom.Rectangle.Contains(res.getBounds(), px, py))
+                continue;
+            const dx = this.player.x - res.x;
+            const dy = this.player.y - res.y;
+            const d2 = dx * dx + dy * dy;
+            if (d2 > pickupRangeSq) continue;
+            res.emit('pointerdown', this._autoPickupPointer);
             if (!res.active) break;
         }
     }


### PR DESCRIPTION
### Summary
- ensure auto-pickup only fires when cursor overlaps a target and the player stands within pickup range
- remove `input.manager.hitTest` calls to cut per-frame allocations

### Technical Approach
- Updated `scenes/MainScene.js` `_attemptAutoPickup` to cache the active pointer's world position, iterate `droppedItems` and `resources` via indexed loops, perform rectangle + distance checks, and trigger pickups or pointer events accordingly

### Performance
- avoids per-frame allocations by reusing `getChildren()` arrays and removing `hitTest` calls
- only lightweight math runs each update

### Risks & Rollback
- potential regression if bounds or range checks differ from previous `hitTest` behavior
- rollback by reverting this commit

### QA Steps
- `npm test`
- Launch game
- Drop an item/resource and hold right-click
- Move cursor over target while walking in/out of pickup range
- Observe pickup only occurs when pointer overlaps and player is within range


------
https://chatgpt.com/codex/tasks/task_e_68acfe788de883228403afb24a0f5bda