### PR TITLE
fix: require right mouse for auto pickup

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -694,12 +694,12 @@ export default class MainScene extends Phaser.Scene {
     // INPUT & COMBAT
     // ==========================
     onPointerDown(pointer) {
-        if (pointer.button === 0) this._scheduleAutoPickup();
+        if (pointer.button === 2) this._scheduleAutoPickup();
         return this.inputSystem.onPointerDown(pointer);
     }
 
     onPointerUp(pointer) {
-        if (pointer.button === 0) this._cancelAutoPickup();
+        if (pointer.button === 2) this._cancelAutoPickup();
         return this.inputSystem.onPointerUp(pointer);
     }
 


### PR DESCRIPTION
### Summary
- use right mouse button for auto-pickup scheduling and cancellation

### Technical Approach
- update `onPointerDown` and `onPointerUp` in `scenes/MainScene.js` to check for `pointer.button === 2`

### Performance
- no per-frame allocations introduced

### Risks & Rollback
- minimal: reverts to previous left-click behavior by reverting commit

### QA Steps
- start a game session
- approach an item/resource
- right-click and hold; verify auto-pickup triggers only within `pickupRange`
- release right button to stop auto-pickup

------
https://chatgpt.com/codex/tasks/task_e_68ad025b02188322b30892a0e94fb73b