### PR TITLE
feat: extract projectile helper

### DIFF
--- a/test/systems/combatSystem.test.js
+++ b/test/systems/combatSystem.test.js
@@ -96,3 +96,30 @@ test('fireRangedWeapon scales velocity and lifetime with time scale', () => {
     assert.equal(Math.round(fast.velMag), 200);
 
 });
+
+test('fireProjectile scales velocity and lifetime with time scale', () => {
+    const run = (scale) => {
+        DevTools.cheats.timeScale = scale;
+        const calls = [];
+        const scene = createStubScene(calls);
+        const combat = createCombatSystem(scene);
+        const pointer = { worldX: 100, worldY: 0 };
+        combat.fireProjectile(pointer, 'rock', {
+            damage: 1,
+            knockback: 0,
+            speed: 100,
+            travel: 100,
+        });
+        const lifetime = calls[0];
+        const velMag = Math.hypot(scene.bullet.vx, scene.bullet.vy);
+        return { lifetime, velMag };
+    };
+
+    const slow = run(0.5);
+    assert.equal(slow.lifetime, 2000);
+    assert.equal(Math.round(slow.velMag), 50);
+
+    const fast = run(2);
+    assert.equal(fast.lifetime, 500);
+    assert.equal(Math.round(fast.velMag), 200);
+});


### PR DESCRIPTION
Summary:
- centralize projectile spawning in `fireProjectile` to reuse across ranged and rock throws
- refactor ranged weapon and rock throw logic to call shared helper
- cover helper with time-scale tests

Technical Approach:
- add `fireProjectile`, refactor `fireRangedWeapon`, add `throwRock` in `systems/combatSystem.js`
- update `test/systems/combatSystem.test.js` with new `fireProjectile` test

Performance:
- retains projectile pooling and time-scale aware lifetime calculations

Risks & Rollback:
- potential edge cases with new helper; revert commit `2d1a9fb` to roll back

QA Steps:
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad03b88e1c8322ae932f1f328af76d