### PR TITLE
feat: speed up auto pickup interval

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -432,7 +432,7 @@ export default class MainScene extends Phaser.Scene {
                 return;
             this._autoPickupActive = true;
             this._autoPickupEvent = this.time.addEvent({
-                delay: 200,
+                delay: 100,
                 loop: true,
                 callback: () => this._attemptAutoPickup(),
             });


### PR DESCRIPTION
## Summary
- accelerate auto pickup to poll every 100ms once active

## Technical Approach
- MainScene._scheduleAutoPickup now creates a 100ms repeating event

## Performance
- reuse existing timer event; no per-frame allocations

## Risks & Rollback
- higher pickup frequency could slightly increase CPU usage
- rollback by restoring delay to 200ms in MainScene._scheduleAutoPickup

## QA Steps
- hold right mouse over dropped items for 2s
- verify items/resources are grabbed roughly every 0.1s


------
https://chatgpt.com/codex/tasks/task_e_68ad05b3d6f483229f829eec54771017