### PR TITLE
fix: pre-night overlay fade

### DIFF
--- a/data/worldGenConfig.js
+++ b/data/worldGenConfig.js
@@ -20,7 +20,7 @@ export const WORLD_GEN = {
   dayNight: {
     dayMs: 240_000,          // 4 min day
     nightMs: 120_000,        // 2 min night
-    transitionMs: 15_000,    // 15s fade at start/end of night
+    transitionMs: 15_000,    // 15s fade before/after night
     nightOverlayAlpha: 0.55, // darkness amount at deepest night (0..1)
     // (You can tweak these freely without touching scene code.)
   },

--- a/systems/dayNightSystem.js
+++ b/systems/dayNightSystem.js
@@ -113,21 +113,18 @@ export default function createDayNightSystem(scene) {
         const duration = getPhaseDuration();
 
         let target = 0;
-        if (scene.phase === 'night') {
-            if (elapsed <= transitionMs) {
-                target = Phaser.Math.Linear(
-                    0,
-                    nightOverlayAlpha,
-                    elapsed / transitionMs,
-                );
-            } else if (elapsed >= duration - transitionMs) {
+        if (scene.phase === 'day') {
+            if (elapsed >= duration - transitionMs) {
+                const t = (elapsed - (duration - transitionMs)) / transitionMs;
+                target = Phaser.Math.Linear(0, nightOverlayAlpha, t);
+            }
+        } else if (scene.phase === 'night') {
+            if (elapsed >= duration - transitionMs) {
                 const t = (elapsed - (duration - transitionMs)) / transitionMs;
                 target = Phaser.Math.Linear(nightOverlayAlpha, 0, t);
             } else {
                 target = nightOverlayAlpha;
             }
-        } else {
-            target = 0;
         }
         scene.nightOverlay.setAlpha(target);
     }


### PR DESCRIPTION
## Summary
- finish night overlay fade before night starts
- clarify day/night transition comment

## Technical Approach
- adjust `updateNightOverlay` in `dayNightSystem`
- update world gen config comment

## Performance
- uses existing per-frame math only
- no new allocations in `updateNightOverlay`

## Risks & Rollback
- potential timing edge cases if day/night durations change
- revert via `git revert` of commit 26d4ee5

## QA Steps
- run `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad06b22d7c83229a9b6b04c68ee326