### PR TITLE
fix: restrict game speed and item spawn inputs

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -655,7 +655,17 @@ export default class DevUIScene extends Phaser.Scene {
             }
             if (/^[0-9]$/.test(ev.key)) {
                 const max = t.text.includes('.') ? 4 : 3;
-                if (t.text.length < max) t.setText(t.text + ev.key);
+                if (t.text.length < max) {
+                    const candidate = t.text + ev.key;
+                    let allow = true;
+                    if (this._editing === this._gameSpeedText) {
+                        allow = parseFloat(candidate) <= 10;
+                    } else if (this._editing === this._itemCountText) {
+                        const maxStack = this._item?.maxStack || 1;
+                        allow = parseInt(candidate, 10) <= maxStack;
+                    }
+                    if (allow) t.setText(candidate);
+                }
                 return;
             }
             if (
@@ -663,7 +673,11 @@ export default class DevUIScene extends Phaser.Scene {
                 this._editing === this._gameSpeedText &&
                 !t.text.includes('.')
             ) {
-                if (t.text.length < 4) t.setText(t.text + '.');
+                const candidate = t.text + '.';
+                if (candidate.length < 4) {
+                    const num = parseFloat(candidate);
+                    if (!Number.isFinite(num) || num <= 10) t.setText(candidate);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent entering game speed above 10
- limit item spawn input to each item's max stack

## Technical Approach
- guard numeric editor in `DevUIScene._onKey` to cap game speed and item spawn counts

## Performance
- simple string/number checks outside update loops; no new per-frame allocations

## Risks & Rollback
- minimal: revert via `git revert 8688a4d`

## QA Steps
- open dev UI
- try entering a game speed above 10; value should clamp
- select an item and attempt to exceed its max stack in the spawn field; value should clamp


------
https://chatgpt.com/codex/tasks/task_e_68ad1336377083228952af147973a0a8