### PR TITLE
feat: lower base player movement speed by 25%

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -628,7 +628,7 @@ export default class MainScene extends Phaser.Scene {
         }
 
         // Movement + sprinting
-        const walkSpeed = 100;
+        const walkSpeed = 75;
         const sprintMult = 1.75;
         const p = this.player.body.velocity;
         p.set(0);


### PR DESCRIPTION
Summary:
- Lower base walk speed to 75 (25% reduction) while keeping sprint multiplier intact.

Technical Approach:
- scenes/MainScene.js: adjust walkSpeed constant in movement update.

Performance:
- Constant change only; no new per-frame allocations.

Risks & Rollback:
- Movement may feel too slow; revert commit 17513b1 to restore previous speed.

QA Steps:
- `npm test`
- Launch the game and verify walking is slower and sprint remains functional.


------
https://chatgpt.com/codex/tasks/task_e_68ad158feb308322b40ecdc7b630a288