### PR TITLE
feat: lower base player movement speed by 25%

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -628,8 +628,8 @@ export default class MainScene extends Phaser.Scene {
         }
 
         // Movement + sprinting
-        const walkSpeed = 100;
-        const sprintMult = 1.75;
+        const walkSpeed = 75;
+        const sprintMult = 1.5;
         const p = this.player.body.velocity;
         p.set(0);
 


### PR DESCRIPTION
Summary:
- Lower base walk speed to 75 (25% reduction) and set sprint to 1.5x base speed.

Technical Approach:
- scenes/MainScene.js: adjust walkSpeed and sprintMult constants in movement update.

Performance:
- Constant changes only; no new per-frame allocations.

Risks & Rollback:
- Movement may feel off; revert commits 41a2a18 and ac30a26 to restore previous speeds.

QA Steps:
- `npm test`
- Launch the game and verify walking is slower and sprint runs at 150% of walk speed.


------
https://chatgpt.com/codex/tasks/task_e_68ad158feb308322b40ecdc7b630a288