### PR TITLE
fix: weapon damage ranges and charge times

### DIFF
--- a/data/itemDatabase.js
+++ b/data/itemDatabase.js
@@ -54,39 +54,41 @@ export const ITEM_DB = {
 
     // data/itemDatabase.js — inside ITEM_DB[ITEM_IDS.SLINGSHOT]
         weapon: {
-      category: WEAPON_CATEGORIES.RANGED,
-      usesAmmo: true,
-      compatibleAmmo: [ITEM_IDS.SLINGSHOT_ROCK],
+            category: WEAPON_CATEGORIES.RANGED,
+            usesAmmo: true,
+            compatibleAmmo: [ITEM_IDS.SLINGSHOT_ROCK],
 
-      // damage/knockback
-      damage: 5,
-      knockback: 5,
+            // damage/knockback
+            minDamage: 5,
+            maxDamage: 5,
+            knockback: 5,
 
-      // Charging support
-      canCharge: true,
-      maxChargeDamage: 10,
-      maxChargeKnockback: 8,
+            // Charging support
+            canCharge: true,
+            chargeMaxMs: 1500,
+            maxChargeDamage: 10,
+            maxChargeKnockback: 8,
 
-      // Tuning
-      projectileTexture: 'slingshot_rock',
-      projectileFrame: null,
-      projectileSpeed: 520,
-      minRange: 250,
-      maxRange: 500,
-      spread: 3,
-      muzzleOffset: { x: 16, y: 6 },
-      fireCooldownMs: 1000, // ranged fire cooldown (ms)
+            // Tuning
+            projectileTexture: 'slingshot_rock',
+            projectileFrame: null,
+            projectileSpeed: 520,
+            minRange: 250,
+            maxRange: 500,
+            spread: 3,
+            muzzleOffset: { x: 16, y: 6 },
+            fireCooldownMs: 1000, // ranged fire cooldown (ms)
 
-      // STAMINA + penalties when stamina is insufficient
-      stamina: {
-        baseCost: 5,             // at 0% charge
-        maxCost: 10,             // at 100% charge
-        poorChargeClamp: 0.15,   // when low stamin max charge is ~15%
-        lowSpeedMultiplier: 0.75,      // e.g., 25% slower when tired
-        lowCooldownMultiplier: 1.5,     // e.g., 1.0s → 1.5s when tired
-        lowRangeMultiplier: 0.6  // e.g., cut travel distance to 60%
-      },
-    },
+            // STAMINA + penalties when stamina is insufficient
+            stamina: {
+                baseCost: 5,             // at 0% charge
+                maxCost: 10,             // at 100% charge
+                poorChargeClamp: 0.15,   // when low stamin max charge is ~15%
+                lowSpeedMultiplier: 0.75,      // e.g., 25% slower when tired
+                lowCooldownMultiplier: 1.5,     // e.g., 1.0s → 1.5s when tired
+                lowRangeMultiplier: 0.6  // e.g., cut travel distance to 60%
+            },
+        },
 
 
 
@@ -112,35 +114,35 @@ export const ITEM_DB = {
 
     // data/itemDatabase.js — inside ITEM_DB[ITEM_IDS.CRUDE_BAT]
     weapon: {
-      category: WEAPON_CATEGORIES.MELEE,
-      usesAmmo: false,
+        category: WEAPON_CATEGORIES.MELEE,
+        usesAmmo: false,
 
-      // Damage & knockback
-      damage: 15,
-      knockback: 15,
+        // Damage & knockback
+        minDamage: 15,
+        maxDamage: 15,
+        knockback: 15,
 
-      // Charging support
-      canCharge: true,
-      chargeMaxMs: 1000, 
-      maxChargeDamage: 20,
-      maxChargeKnockback: 25,
+        // Charging support
+        canCharge: true,
+        chargeMaxMs: 2000,
+        maxChargeDamage: 20,
+        maxChargeKnockback: 25,
 
-      // Swing tuning
-      swingDurationMs: 160,
-      swingCooldownMs: 100,
-      chargeMaxMs: 2000,
+        // Swing tuning
+        swingDurationMs: 160,
+        swingCooldownMs: 100,
 
-      // Hit shape/reach
-      range: 30,
-      radius: 22,
+        // Hit shape/reach
+        range: 30,
+        radius: 22,
 
-      // STAMINA + penalties when stamina is insufficient
-      stamina: {
-        cost: 15,
-        slowMultiplier: 6,
-        cooldownMultiplier: 12,
-        poorChargeClamp: 0.25,
-      },
+        // STAMINA + penalties when stamina is insufficient
+        stamina: {
+            cost: 15,
+            slowMultiplier: 6,
+            cooldownMultiplier: 12,
+            poorChargeClamp: 0.25,
+        },
     },
 
     sounds: {

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -35,12 +35,11 @@ export default function createCombatSystem(scene) {
         const baseD = hit.getData('damage');
         const baseKb = hit.getData('knockback');
         const meleeMult = Math.max(0, zombie?.resist?.meleeMult ?? 1);
-        const dmg = Math.max(
-            0,
-            Math.round(
-                (baseD ?? ITEM_DB?.crude_bat?.weapon?.damage ?? 10) * meleeMult,
-            ),
-        );
+        const defMin = ITEM_DB?.crude_bat?.weapon?.minDamage ?? 10;
+        const defMax = ITEM_DB?.crude_bat?.weapon?.maxDamage ?? defMin;
+        const rawD =
+            baseD ?? Phaser.Math.Between(defMin, defMax);
+        const dmg = Math.max(0, Math.round(rawD * meleeMult));
         const kb = Math.max(
             0,
             baseKb ?? ITEM_DB?.crude_bat?.weapon?.knockback ?? 10,
@@ -59,10 +58,12 @@ export default function createCombatSystem(scene) {
             typeof bullet.getData === 'function'
                 ? bullet.getData('knockback')
                 : undefined;
+        const slMin = ITEM_DB?.slingshot?.weapon?.minDamage ?? 5;
+        const slMax = ITEM_DB?.slingshot?.weapon?.maxDamage ?? slMin;
         let dmg =
             typeof payloadDmg === 'number'
                 ? payloadDmg
-                : (ITEM_DB?.slingshot?.weapon?.damage ?? 5);
+                : Phaser.Math.Between(slMin, slMax);
         let kb =
             typeof payloadKb === 'number'
                 ? payloadKb
@@ -239,8 +240,10 @@ export default function createCombatSystem(scene) {
         const uiPercent = Phaser.Math.Clamp(effectiveCharge / maxCap, 0, 1);
         scene.uiScene?.events?.emit('weapon:charge', uiPercent);
         const canCharge = wpn?.canCharge === true;
-        const baseDmg = wpn?.damage ?? 6;
-        const maxDmg = wpn?.maxChargeDamage ?? baseDmg;
+        const baseMin = wpn?.minDamage ?? wpn?.damage ?? 6;
+        const baseMax = wpn?.maxDamage ?? baseMin;
+        const baseDmg = Phaser.Math.Between(baseMin, baseMax);
+        const maxDmg = wpn?.maxChargeDamage ?? baseMax;
         let shotDmg = canCharge
             ? Phaser.Math.Linear(baseDmg, maxDmg, effectiveCharge)
             : baseDmg;
@@ -351,9 +354,11 @@ export default function createCombatSystem(scene) {
         if (lowStamina && st && typeof st.poorChargeClamp === 'number') {
             charge = Math.min(charge, st.poorChargeClamp);
         }
-        const baseDmg = wpn?.damage ?? 10;
+        const baseMin = wpn?.minDamage ?? wpn?.damage ?? 10;
+        const baseMax = wpn?.maxDamage ?? baseMin;
+        const baseDmg = Phaser.Math.Between(baseMin, baseMax);
         const baseKb = wpn?.knockback ?? 10;
-        const maxDmg = wpn?.maxChargeDamage ?? baseDmg;
+        const maxDmg = wpn?.maxChargeDamage ?? baseMax;
         const maxKb = wpn?.maxChargeKnockback ?? baseKb;
         let swingDamage = canCharge
             ? Phaser.Math.Linear(baseDmg, maxDmg, charge)

--- a/test/systems/combatSystem.test.js
+++ b/test/systems/combatSystem.test.js
@@ -7,6 +7,7 @@ globalThis.Phaser = {
     Math: {
         Clamp: (v, min, max) => Math.min(Math.max(v, min), max),
         Linear: (start, end, t) => start + (end - start) * t,
+        Between: (min, max) => min,
         Angle: {
             Between: (x1, y1, x2, y2) => Math.atan2(y2 - y1, x2 - x1),
         },


### PR DESCRIPTION
Summary:
- add min/max damage and explicit charge times to weapons so configs are flexible and clear

Technical Approach:
- data/itemDatabase.js defines `minDamage`, `maxDamage`, and `chargeMaxMs` for weapons
- systems/combatSystem.js reads damage ranges when firing or swinging
- test/systems/combatSystem.test.js stubs Phaser.Math.Between

Performance:
- added only simple math; no new per-frame allocations

Risks & Rollback:
- misconfigured weapon stats could skew balance; revert commit 1a5809e if needed

QA Steps:
- start game and equip slingshot; verify damage scales between min/max and charge time caps at 1.5s
- equip crude bat; verify damage range and 2s max charge


------
https://chatgpt.com/codex/tasks/task_e_68ad17e970c08322bf6d6f9457feabba