### PR TITLE
feat: enable hotbar rock throws

### DIFF
--- a/data/itemDatabase.js
+++ b/data/itemDatabase.js
@@ -182,54 +182,87 @@ export const ITEM_DB = {
   },
 
   //-------------------------------
-  // Resources
+  // Materials / throwable rocks
   //-------------------------------
 
   [ITEM_IDS.ROCK1A]: {
     id: ITEM_IDS.ROCK1A,
     name: 'Small Rock',
-    type: ITEM_TYPES.RESOURCE,
+    type: ITEM_TYPES.AMMO,
     stackable: true,
     maxStack: 99,
 
     icon: { textureKey: 'rock1A', scale: 1.0, ox: 0, oy: 0 },
     world: { textureKey: 'rock1A', scale: .65 },
 
+    showCountOnIcon: true,
     sounds: { pickup: 'sfx_pickup_small' },
 
-    tags: ['resource', 'rock'],
+    ammo: {
+      minDamage: 1,
+      maxDamage: 3,
+      minRange: 50,
+      maxRange: 100,
+      maxChargeMs: 2000,
+      speed: 300,
+      knockback: 0,
+    },
+
+    tags: ['ammo', 'material', 'rock'],
     meta: { rarity: 'common' },
   },
 
   [ITEM_IDS.ROCK2A]: {
     id: ITEM_IDS.ROCK2A,
     name: 'Small Grassy Rock',
-    type: ITEM_TYPES.RESOURCE,
+    type: ITEM_TYPES.AMMO,
     stackable: true,
     maxStack: 99,
 
     icon: { textureKey: 'rock2A', scale: 1.0, ox: 0, oy: 0 },
     world: { textureKey: 'rock2A', scale: .65 },
 
+    showCountOnIcon: true,
     sounds: { pickup: 'sfx_pickup_small' },
 
-    tags: ['resource', 'rock'],
+    ammo: {
+      minDamage: 1,
+      maxDamage: 3,
+      minRange: 50,
+      maxRange: 100,
+      maxChargeMs: 2000,
+      speed: 300,
+      knockback: 0,
+    },
+
+    tags: ['ammo', 'material', 'rock'],
     meta: { rarity: 'common' },
   },
 
   [ITEM_IDS.ROCK5A]: {
     id: ITEM_IDS.ROCK5A,
     name: 'Small Marble Rock',
-    type: ITEM_TYPES.RESOURCE,
+    type: ITEM_TYPES.AMMO,
     stackable: true,
     maxStack: 99,
 
     icon: { textureKey: 'rock5A', scale: 1.0, ox: 0, oy: 0 },
     world: { textureKey: 'rock5A', scale: .65 },
 
+    showCountOnIcon: true,
     sounds: { pickup: 'sfx_pickup_small' },
 
-    tags: ['resource', 'rock'],
+    ammo: {
+      minDamage: 1,
+      maxDamage: 3,
+      minRange: 50,
+      maxRange: 100,
+      maxChargeMs: 2000,
+      speed: 300,
+      knockback: 0,
+    },
+
+    tags: ['ammo', 'material', 'rock'],
     meta: { rarity: 'common' },
   },
 
@@ -237,6 +270,11 @@ export const ITEM_DB = {
 
 export const GROUPS = {
   weapons: [ITEM_IDS.SLINGSHOT, ITEM_IDS.CRUDE_BAT],
-  ammo: [ITEM_IDS.SLINGSHOT_ROCK ],
-  resources: [ITEM_IDS.ROCK1A, ITEM_IDS.ROCK2A, ITEM_IDS.ROCK5A],
+  ammo: [
+    ITEM_IDS.SLINGSHOT_ROCK,
+    ITEM_IDS.ROCK1A,
+    ITEM_IDS.ROCK2A,
+    ITEM_IDS.ROCK5A,
+  ],
+  materials: [ITEM_IDS.ROCK1A, ITEM_IDS.ROCK2A, ITEM_IDS.ROCK5A],
 };

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -291,13 +291,26 @@ export default function createCombatSystem(scene) {
         scene.uiScene?.events?.emit('weapon:chargeEnd');
     }
 
-    function throwRock(pointer) {
-        const damage = Phaser.Math.Between(1, 3);
-        const travel = Phaser.Math.Between(50, 100);
-        const speed = 300;
-        fireProjectile(pointer, 'slingshot_rock', {
+    function throwRock(pointer, itemId, chargePercent = 0) {
+        if (!pointer || !itemId) return;
+        const def = ITEM_DB[itemId];
+        const ammoCfg = def?.ammo || {};
+        const charge = Phaser.Math.Clamp(chargePercent || 0, 0, 1);
+        const minD = ammoCfg.minDamage ?? 1;
+        const maxD = ammoCfg.maxDamage ?? 3;
+        const damage = Phaser.Math.Linear(minD, maxD, charge);
+        const minR = ammoCfg.minRange ?? 50;
+        const maxR = ammoCfg.maxRange ?? 100;
+        const travel = Phaser.Math.Linear(minR, maxR, charge);
+        const speed = ammoCfg.speed ?? 300;
+        const knockback = ammoCfg.knockback ?? 0;
+        const tex = def?.icon?.textureKey || 'slingshot_rock';
+        if (DevTools.shouldConsumeAmmo()) {
+            scene.uiScene?.inventory?.consumeAmmo?.(itemId, 1);
+        }
+        fireProjectile(pointer, tex, {
             damage,
-            knockback: 0,
+            knockback,
             speed,
             travel,
         });

--- a/systems/inputSystem.js
+++ b/systems/inputSystem.js
@@ -67,6 +67,23 @@ export default function createInputSystem(scene) {
             scene._updateEquippedItemGhost();
             return;
         }
+
+        if (def?.ammo && def.tags?.includes('rock')) {
+            const now = scene.time.now;
+            scene.isCharging = true;
+            scene.chargeStart = now;
+            const scale = DevTools.cheats.timeScale || 1;
+            const applied = scale <= 0 ? 0 : 1 / scale;
+            scene.chargeMaxMs = Math.max(
+                1,
+                Math.floor((def.ammo?.maxChargeMs ?? 2000) * applied),
+            );
+            scene._chargingItemId = equipped.id;
+            scene.uiScene?.events?.emit('weapon:charge', 0);
+            scene._createEquippedItemGhost?.(equipped.id);
+            scene._updateEquippedItemGhost();
+            return;
+        }
     }
 
     function onPointerUp(pointer) {
@@ -101,6 +118,11 @@ export default function createInputSystem(scene) {
 
         if (cat === 'melee' && eq.id === 'crude_bat') {
             scene.combat.swingBat(pointer, def.weapon || {}, charge);
+            return;
+        }
+
+        if (def?.ammo && def.tags?.includes('rock')) {
+            scene.combat.throwRock(pointer, eq.id, charge);
             return;
         }
     }


### PR DESCRIPTION
## Summary
- allow rocks in hotbar to charge and throw as projectiles
- rename resource tags to material and treat rocks as ammo

## Technical Approach
- add rock ammo stats in `data/itemDatabase.js`
- route rock input events to `throwRock` in `systems/inputSystem.js`
- generate projectile from rock config in `systems/combatSystem.js`

## Performance
- reuses existing projectile pooling
- avoids new allocations during `update`

## Risks & Rollback
- rock items may need future tuning for balance
- revert via `git revert 0546f80`

## QA Steps
- equip a rock in the hotbar
- hold left click to charge and release to throw
- verify rock count decreases


------
https://chatgpt.com/codex/tasks/task_e_68ad12faa39c8322893ec16579d10c9a