### PR TITLE
feat: add charge bar for rock throws

### DIFF
--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -723,11 +723,13 @@ export default class UIScene extends Phaser.Scene {
         const vis = this.bottomHotbarVisuals[idx];
         if (!vis) return;
 
-        // ✅ Show charge bar for ANY equipped weapon that supports charging
+        // ✅ Show charge bar for any equipped item that supports charging
         const eq = this.inventory.getEquipped?.();
+        const item = eq ? ITEM_DB?.[eq.id] : null;
         const canCharge =
-            !!eq &&
-            ITEM_DB?.[eq.id]?.weapon?.canCharge === true;
+            !!item &&
+            (item?.weapon?.canCharge === true ||
+                (item?.ammo && item.tags?.includes('rock')));
 
         if (!canCharge) {
             this.#hideChargeUIForAll();


### PR DESCRIPTION
Summary:
- Show charging progress when holding rocks before throwing.

Technical Approach:
- scenes/MainScene.js: _tickChargeUi now emits charge updates for items with rock ammo.
- scenes/UIScene.js: #updateChargeBar accepts rock ammo items.

Performance:
- Uses existing charge update loop with only arithmetic; no allocations in update().

Risks & Rollback:
- Charge bar may appear for unintended ammo types; revert commit f34f0b5.

QA Steps:
- Equip a rock in the hotbar.
- Hold left mouse to begin throw; bar fills up.
- Release to throw; bar disappears.


------
https://chatgpt.com/codex/tasks/task_e_68ad1b75ce808322a4fc4736f418c918