### PR TITLE
fix: shorten auto pickup activation delay

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -436,7 +436,7 @@ export default class MainScene extends Phaser.Scene {
 
     _scheduleAutoPickup() {
         this._cancelAutoPickup();
-        this._autoPickupTimer = this.time.delayedCall(2000, () => {
+        this._autoPickupTimer = this.time.delayedCall(1000, () => {
             if (this.isCharging || !this.input.activePointer.rightButtonDown())
                 return;
             this._autoPickupActive = true;


### PR DESCRIPTION
### Summary
- lower auto pickup hold duration to 1 second

### Technical Approach
- adjust `_scheduleAutoPickup` timer in `scenes/MainScene.js`

### Performance
- uses existing timers; no added per-frame allocations

### Risks & Rollback
- accidental quick activation if player briefly holds button; revert commit 0294b0d to restore 2s delay

### QA Steps
- hold right mouse near a pickup for 1s and verify auto pickup begins
- release right mouse before 1s and confirm auto pickup does not start

------
https://chatgpt.com/codex/tasks/task_e_68ad1ba003e4832291405592e0243d58