### PR TITLE
Add day/night zombie trickle spawns

### DIFF
--- a/data/worldGenConfig.js
+++ b/data/worldGenConfig.js
@@ -103,9 +103,16 @@ export const WORLD_GEN = {
     zombie: {
       // DAY: Rare trickle
       day: {
-        minDelayMs: 6_000,   // random interval between checks
-        maxDelayMs: 12_000,
-        chance: 0.25,        // 25% chance to spawn 1 when timer fires
+        minDelayMs: 20_000,  // fixed interval between checks
+        maxDelayMs: 20_000,
+        chance: 0.15,        // 15% chance to spawn 1 when timer fires
+      },
+
+      // NIGHT: Occasional trickle
+      nightTrickle: {
+        minDelayMs: 20_000,
+        maxDelayMs: 20_000,
+        chance: 0.5,        // 50% chance to spawn 1 when timer fires
       },
 
       // NIGHT: Waves

--- a/systems/dayNightSystem.js
+++ b/systems/dayNightSystem.js
@@ -32,6 +32,7 @@ export default function createDayNightSystem(scene) {
         }
         scene.waveNumber = 0;
         scheduleNightWave();
+        scheduleNightTrickle();
         updateTimeUi();
     }
 
@@ -55,6 +56,32 @@ export default function createDayNightSystem(scene) {
                     scene.combat.spawnZombie(id);
                 }
                 scheduleDaySpawn();
+            },
+        });
+    }
+
+    function scheduleNightTrickle() {
+        const nightCfg = WORLD_GEN.spawns.zombie.nightTrickle;
+        const delay = Phaser.Math.Between(
+            nightCfg.minDelayMs,
+            nightCfg.maxDelayMs,
+        );
+        if (scene.spawnZombieTimer) {
+            scene.spawnZombieTimer.remove(false);
+            scene.spawnZombieTimer = null;
+        }
+        scene.spawnZombieTimer = scene.time.addEvent({
+            delay,
+            loop: false,
+            callback: () => {
+                if (scene.phase !== 'night' || scene.isGameOver) return;
+                if (Math.random() < nightCfg.chance) {
+                    const types =
+                        scene.combat.getEligibleZombieTypesForPhase('night');
+                    const id = scene.combat.pickZombieTypeWeighted(types);
+                    scene.combat.spawnZombie(id);
+                }
+                scheduleNightTrickle();
             },
         });
     }
@@ -158,6 +185,7 @@ export default function createDayNightSystem(scene) {
         startDay,
         startNight,
         scheduleDaySpawn,
+        scheduleNightTrickle,
         scheduleNightWave,
         getPhaseElapsed,
         getPhaseDuration,


### PR DESCRIPTION
## Summary
- tune day trickle to 15% chance every 20 seconds
- add 50% night trickle spawn every 20 seconds alongside waves

## Technical Approach
- update `data/worldGenConfig.js` with fixed 20s intervals and new nightTrickle config
- extend `systems/dayNightSystem.js` to schedule `nightTrickle` and call it on night start

## Performance
- reuses existing timer, no per-frame allocations; checks run only every 20s

## Risks & Rollback
- increased spawn rate could crowd play area; revert with `git revert b7ba20c`

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1c580164832299e661955ec1226c