### PR TITLE
feat: reorganize world generation modules

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -133,6 +133,7 @@ export default class DevUIScene extends Phaser.Scene {
         let y = 0;
         y = this._sectionTitle('Cheats', y);
         y = this._rowToggle('Show Hitboxes', () => DevTools.cheats.showHitboxes, v => DevTools.setShowHitboxes(v), y);
+        y = this._rowToggle('Show Chunk Bounds', () => DevTools.cheats.showChunks, v => DevTools.setShowChunks(v), y);
         y = this._rowToggle('Invisible',      () => DevTools.cheats.invisible,    v => DevTools.cheats.invisible = v, y);
         y = this._rowToggle('Infinite Health',() => DevTools.cheats.invincible,   v => {
             DevTools.cheats.invincible = v;

--- a/systems/worldGen/ChunkCache.js
+++ b/systems/worldGen/ChunkCache.js
@@ -1,0 +1,17 @@
+export default class ChunkCache {
+    constructor() {
+        this._cache = new Map();
+    }
+
+    get(chunkX, chunkY) {
+        return this._cache.get(`${chunkX},${chunkY}`) || null;
+    }
+
+    set(chunkX, chunkY, data) {
+        this._cache.set(`${chunkX},${chunkY}`, data);
+    }
+
+    delete(chunkX, chunkY) {
+        this._cache.delete(`${chunkX},${chunkY}`);
+    }
+}

--- a/systems/worldGen/ChunkLoader.js
+++ b/systems/worldGen/ChunkLoader.js
@@ -1,0 +1,14 @@
+export default class ChunkLoader {
+    constructor(scene) {
+        this.scene = scene;
+    }
+
+    load(chunkX, chunkY) {
+        // TODO: load terrain or metadata for this chunk
+        return null;
+    }
+
+    unload(chunkX, chunkY) {
+        // TODO: persist changes or free resources for this chunk
+    }
+}

--- a/systems/worldGen/ChunkManager.js
+++ b/systems/worldGen/ChunkManager.js
@@ -1,0 +1,81 @@
+import ChunkLoader from './ChunkLoader.js';
+import ChunkSpawner from './ChunkSpawner.js';
+import ChunkCache from './ChunkCache.js';
+import ChunkPathGrid from './ChunkPathGrid.js';
+
+export default class ChunkManager {
+    constructor(scene, opts = {}) {
+        this.scene = scene;
+        this.chunkWidth = opts.chunkWidth || 400;
+        this.chunkHeight = opts.chunkHeight || 300;
+        this.radius = opts.radius || 1;
+        this.active = new Map();
+        this._lastChunkX = NaN;
+        this._lastChunkY = NaN;
+
+        this.loader = new ChunkLoader(scene);
+        this.spawner = new ChunkSpawner(scene);
+        this.cache = new ChunkCache();
+        this.pathGrid = new ChunkPathGrid();
+    }
+
+    static rng(seed) {
+        return function () {
+            seed |= 0;
+            seed = (seed + 0x6d2b79f5) | 0;
+            let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+            t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+        };
+    }
+
+    _seed(x, y) {
+        let s = x * 374761393 + y * 668265263;
+        s = (s ^ (s >> 13)) >>> 0;
+        return s;
+    }
+
+    update() {
+        const player = this.scene.player;
+        if (!player) return;
+        const cx = Math.floor(player.x / this.chunkWidth);
+        const cy = Math.floor(player.y / this.chunkHeight);
+        if (cx === this._lastChunkX && cy === this._lastChunkY) return;
+        this._lastChunkX = cx;
+        this._lastChunkY = cy;
+
+        const needed = new Set();
+        for (let dx = -this.radius; dx <= this.radius; dx++) {
+            for (let dy = -this.radius; dy <= this.radius; dy++) {
+                const nx = cx + dx;
+                const ny = cy + dy;
+                const key = `${nx},${ny}`;
+                needed.add(key);
+                if (!this.active.has(key)) {
+                    const seed = this._seed(nx, ny);
+                    const data = this.loader.load(nx, ny);
+                    this.cache.set(nx, ny, data);
+                    this.pathGrid.build(nx, ny, data);
+                    this.spawner.activate(nx, ny, seed, data);
+                    this.active.set(key, { chunkX: nx, chunkY: ny, seed });
+                    this.scene.events.emit('chunk:activate', {
+                        chunkX: nx,
+                        chunkY: ny,
+                        seed,
+                    });
+                }
+            }
+        }
+
+        for (const key of Array.from(this.active.keys())) {
+            if (!needed.has(key)) {
+                const info = this.active.get(key);
+                this.spawner.deactivate(info.chunkX, info.chunkY);
+                this.loader.unload(info.chunkX, info.chunkY);
+                this.cache.delete(info.chunkX, info.chunkY);
+                this.scene.events.emit('chunk:deactivate', info);
+                this.active.delete(key);
+            }
+        }
+    }
+}

--- a/systems/worldGen/ChunkPathGrid.js
+++ b/systems/worldGen/ChunkPathGrid.js
@@ -1,0 +1,9 @@
+export default class ChunkPathGrid {
+    constructor() {
+        // TODO: build navigation grids per chunk
+    }
+
+    build(chunkX, chunkY, data) {
+        // TODO: compute pathing grid from chunk data
+    }
+}

--- a/systems/worldGen/ChunkSpawner.js
+++ b/systems/worldGen/ChunkSpawner.js
@@ -1,0 +1,13 @@
+export default class ChunkSpawner {
+    constructor(scene) {
+        this.scene = scene;
+    }
+
+    activate(chunkX, chunkY, seed, data) {
+        // TODO: spawn entities/resources for this chunk using seed and data
+    }
+
+    deactivate(chunkX, chunkY) {
+        // TODO: remove or recycle entities/resources for this chunk
+    }
+}

--- a/systems/worldGen/dayNightSystem.js
+++ b/systems/worldGen/dayNightSystem.js
@@ -1,7 +1,7 @@
 // systems/dayNightSystem.js
 // Day/Night cycle logic isolated from Phaser scene for reuse.
-import { WORLD_GEN } from '../data/worldGenConfig.js';
-import DevTools from './DevTools.js';
+import { WORLD_GEN } from './worldGenConfig.js';
+import DevTools from '../DevTools.js';
 
 export default function createDayNightSystem(scene) {
     // ----- Phase Transitions -----

--- a/systems/worldGen/worldGenConfig.js
+++ b/systems/worldGen/worldGenConfig.js
@@ -1,15 +1,15 @@
 // data/worldGenConfig.js
 // PURE DATA ONLY — no logic. Tunable world gen + day/night + spawn settings.
 
-import { RESOURCE_IDS } from './resourceDatabase.js';
+import { RESOURCE_IDS } from '../../data/resourceDatabase.js';
 
 export const WORLD_GEN = {
   // -----------------------------
   // World bounds / scale (future)
   // -----------------------------
   world: {
-    width: 1200,   // logical world width (px). You can expand later.
-    height: 900,   // logical world height (px).
+    width: 8000,   // logical world width (px). You can expand later.
+    height: 8000,   // logical world height (px).
   },
 
   // -----------------------------

--- a/test/systems/dayNightSystem.test.js
+++ b/test/systems/dayNightSystem.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import createDayNightSystem from '../../systems/dayNightSystem.js';
+import createDayNightSystem from '../../systems/worldGen/dayNightSystem.js';
 import DevTools from '../../systems/DevTools.js';
 
 globalThis.Phaser = {


### PR DESCRIPTION
## Summary
- group world-gen systems under `systems/worldGen`
- scaffold chunk loader/spawner/cache/path grid and wire into manager
- add chunk boundary debug overlay with Dev Tools toggle

## Technical Approach
- moved `dayNightSystem` and `worldGenConfig` into `systems/worldGen`
- expanded `ChunkManager` and added `ChunkLoader|Spawner|Cache|PathGrid`
- extended `DevTools` and `DevUIScene` to toggle chunk boundary graphics

## Performance
- debug layers reuse pooled `Graphics`; no per-frame allocations
- world-gen stubs idle until implemented

## Risks & Rollback
- import path regressions from file moves
- revert via `git revert` of the two commits if integration issues arise

## QA Steps
- `npm test`
- launch the game, open Dev UI, toggle **Show Chunk Bounds** and verify grid lines appear

------
https://chatgpt.com/codex/tasks/task_e_68ad05e793d08322b32d723b84ff975c