### PR TITLE
feat: add charge bar for rock throws

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -24,7 +24,7 @@ export default class MainScene extends Phaser.Scene {
         this.isCharging = false;
         this._chargingItemId = null; // which item started the current charge; null when not charging
         this.chargeStart = 0;
-        this.chargeMaxMs = 1500; // 1.5s charge UI cap
+        this.chargeMaxMs = 2000; // 2s charge UI cap
         this.lastCharge = 0; // 0..1 captured on release
 
         // Melee swing state
@@ -898,8 +898,12 @@ export default class MainScene extends Phaser.Scene {
         const eq = this.uiScene?.inventory?.getEquipped?.();
         if (!eq) return;
 
-        const wpnDef = ITEM_DB?.[eq.id]?.weapon;
-        if (!wpnDef || wpnDef.canCharge !== true) return;
+        const item = ITEM_DB?.[eq.id];
+        const wpnDef = item?.weapon;
+        const ammoDef = item?.ammo;
+        const canChargeWpn = wpnDef?.canCharge === true;
+        const canChargeAmmo = !!ammoDef && item.tags?.includes('rock');
+        if (!canChargeWpn && !canChargeAmmo) return;
 
         // Raw 0..1 charge based on time held
         const heldMs = Phaser.Math.Clamp(
@@ -909,29 +913,32 @@ export default class MainScene extends Phaser.Scene {
         );
         const raw = this.chargeMaxMs > 0 ? heldMs / this.chargeMaxMs : 1;
 
-        // Predict low-stamina condition without spending stamina
-        const st = wpnDef.stamina || {};
-        let predictLowStamina = false;
-        let estCost = 0;
-        if (typeof st.baseCost === 'number' && typeof st.maxCost === 'number') {
-            estCost = Phaser.Math.Linear(st.baseCost, st.maxCost, raw);
-        } else if (typeof st.cost === 'number') {
-            estCost = st.cost;
+        let uiPercent;
+        if (canChargeWpn) {
+            const st = wpnDef.stamina || {};
+            let predictLowStamina = false;
+            let estCost = 0;
+            if (
+                typeof st.baseCost === 'number' &&
+                typeof st.maxCost === 'number'
+            ) {
+                estCost = Phaser.Math.Linear(st.baseCost, st.maxCost, raw);
+            } else if (typeof st.cost === 'number') {
+                estCost = st.cost;
+            }
+            if (estCost > 0 && this.stamina < estCost) predictLowStamina = true;
+
+            const maxCap =
+                predictLowStamina && typeof st.poorChargeClamp === 'number'
+                    ? Math.max(0.0001, st.poorChargeClamp)
+                    : 1;
+
+            const effective = Math.min(raw, maxCap);
+            uiPercent = Phaser.Math.Clamp(effective, 0, 1);
+        } else {
+            uiPercent = Phaser.Math.Clamp(raw, 0, 1);
         }
-        if (estCost > 0 && this.stamina < estCost) predictLowStamina = true;
 
-        // Max cap when tired; actual effective charge is clamped
-        const maxCap =
-            predictLowStamina && typeof st.poorChargeClamp === 'number'
-                ? Math.max(0.0001, st.poorChargeClamp)
-                : 1;
-
-        const effective = Math.min(raw, maxCap); // clamped effective charge
-
-        // Emit percent directly as the bar fill amount (no normalization)
-        const uiPercent = Phaser.Math.Clamp(effective, 0, 1);
-
-        // Emit only when visibly different
         if (Math.abs((uiPercent || 0) - (this.lastCharge || 0)) >= 0.01) {
             this.lastCharge = uiPercent;
             this.uiScene?.events?.emit('weapon:charge', uiPercent);

--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -723,11 +723,13 @@ export default class UIScene extends Phaser.Scene {
         const vis = this.bottomHotbarVisuals[idx];
         if (!vis) return;
 
-        // ✅ Show charge bar for ANY equipped weapon that supports charging
+        // ✅ Show charge bar for any equipped item that supports charging
         const eq = this.inventory.getEquipped?.();
+        const item = eq ? ITEM_DB?.[eq.id] : null;
         const canCharge =
-            !!eq &&
-            ITEM_DB?.[eq.id]?.weapon?.canCharge === true;
+            !!item &&
+            (item?.weapon?.canCharge === true ||
+                (item?.ammo && item.tags?.includes('rock')));
 
         if (!canCharge) {
             this.#hideChargeUIForAll();

--- a/systems/inputSystem.js
+++ b/systems/inputSystem.js
@@ -29,7 +29,7 @@ export default function createInputSystem(scene) {
                 scene.chargeStart = now;
                 const scale = DevTools.cheats.timeScale || 1;
                 const applied = scale <= 0 ? 0 : 1 / scale;
-                scene.chargeMaxMs = Math.max(1, Math.floor((wpn?.chargeMaxMs ?? 1500) * applied));
+                scene.chargeMaxMs = Math.max(1, Math.floor((wpn?.chargeMaxMs ?? 2000) * applied));
                 scene._chargingItemId = equipped.id;
                 scene.uiScene?.events?.emit('weapon:charge', 0);
                 scene._createEquippedItemGhost?.(equipped.id);
@@ -60,7 +60,7 @@ export default function createInputSystem(scene) {
             scene.chargeStart = now;
             const scale = DevTools.cheats.timeScale || 1;
             const applied = scale <= 0 ? 0 : 1 / scale;
-            scene.chargeMaxMs = Math.max(1, Math.floor((wpn?.chargeMaxMs ?? 1500) * applied));
+            scene.chargeMaxMs = Math.max(1, Math.floor((wpn?.chargeMaxMs ?? 2000) * applied));
             scene._chargingItemId = equipped.id;
             scene.uiScene?.events?.emit('weapon:charge', 0);
             scene._createEquippedItemGhost?.(equipped.id);


### PR DESCRIPTION
Summary:
- Show charging progress when holding rocks before throwing.
- Charge bar fills over two seconds for rock throws and other unspecified chargeable items.

Technical Approach:
- scenes/MainScene.js: set default `chargeMaxMs` to 2000 for a 2s UI cap.
- systems/inputSystem.js: default weapon charge durations to 2000ms when undefined.

Performance:
- Uses existing charge update loop with only arithmetic; no allocations in update().

Risks & Rollback:
- Longer default charge could slow unconfigured weapons; revert commit 3e743fd.

QA Steps:
- Equip a rock in the hotbar.
- Hold left mouse to begin throw; bar fills over ~2 seconds.
- Release to throw; bar disappears.
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b75ce808322a4fc4736f418c918