### PR TITLE
feat: stub chunk helpers and chunk bounds toggle

### DIFF
--- a/chunk/ChunkCache.js
+++ b/chunk/ChunkCache.js
@@ -1,0 +1,16 @@
+export default class ChunkCache {
+    constructor() {
+        // TODO: setup persistence for chunk state
+        this._cache = new Map();
+    }
+
+    save(key, state) {
+        // TODO: persist state for the given chunk
+        this._cache.set(key, state);
+    }
+
+    restore(key) {
+        // TODO: return saved state for the given chunk or null
+        return this._cache.get(key) || null;
+    }
+}

--- a/chunk/ChunkLoader.js
+++ b/chunk/ChunkLoader.js
@@ -1,0 +1,10 @@
+export default class ChunkLoader {
+    constructor() {
+        // TODO: initialize loader for chunk metadata
+    }
+
+    load(chunkX, chunkY) {
+        // TODO: load or procedurally generate metadata for the given chunk
+        return null;
+    }
+}

--- a/chunk/ChunkPathGrid.js
+++ b/chunk/ChunkPathGrid.js
@@ -1,0 +1,4 @@
+export function getChunkPathGrid(chunkMeta) {
+    // TODO: expose chunk-level pathfinding grid
+    return null;
+}

--- a/chunk/ChunkSpawner.js
+++ b/chunk/ChunkSpawner.js
@@ -1,0 +1,14 @@
+export default class ChunkSpawner {
+    constructor(rng) {
+        this.rng = rng;
+        // TODO: seedable RNG for deterministic spawning
+    }
+
+    spawn(scene, chunkMeta) {
+        // TODO: spawn entities for the chunk
+    }
+
+    despawn(scene, chunkMeta) {
+        // TODO: remove entities when chunk is deactivated
+    }
+}

--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -133,6 +133,7 @@ export default class DevUIScene extends Phaser.Scene {
         let y = 0;
         y = this._sectionTitle('Cheats', y);
         y = this._rowToggle('Show Hitboxes', () => DevTools.cheats.showHitboxes, v => DevTools.setShowHitboxes(v), y);
+        y = this._rowToggle('Show Chunk Bounds', () => DevTools.cheats.showChunkBounds, v => DevTools.toggleChunkBounds(v, this.scene.get('MainScene')), y);
         y = this._rowToggle('Invisible',      () => DevTools.cheats.invisible,    v => DevTools.cheats.invisible = v, y);
         y = this._rowToggle('Infinite Health',() => DevTools.cheats.invincible,   v => {
             DevTools.cheats.invincible = v;
@@ -179,9 +180,11 @@ export default class DevUIScene extends Phaser.Scene {
             if (!consumed) this._scrollBy(dy); // otherwise scroll the whole panel
         });
 
-        // Make sure hitbox render and game speed react immediately
-        DevTools.applyHitboxCheat(this.scene.get('MainScene'));
+        // Make sure hitbox render, chunk bounds, and game speed react immediately
+        const mainScene = this.scene.get('MainScene');
+        DevTools.applyHitboxCheat(mainScene);
         DevTools.applyTimeScale(this);
+        DevTools.toggleChunkBounds(DevTools.cheats.showChunkBounds, mainScene);
     }
 
     // ---------- Section builders ----------


### PR DESCRIPTION
Summary:
- stub chunk helper modules and add developer chunk bounds overlay toggle

Technical Approach:
- `chunk/ChunkLoader.js`, `chunk/ChunkSpawner.js`, `chunk/ChunkCache.js`, `chunk/ChunkPathGrid.js` stubbed with TODO placeholders
- `systems/DevTools.js` adds `showChunkBounds` flag and `toggleChunkBounds()` using reusable `Graphics`
- `scenes/DevUIScene.js` exposes a "Show Chunk Bounds" toggle that calls the new DevTools method

Performance:
- overlays reuse a single `Graphics` instance to avoid per-frame allocations

Risks & Rollback:
- overlay depends on `MainScene`; if missing, toggle is a no-op
- revert commit to remove chunk tools and toggle

QA Steps:
- `npm test`
- launch game and open Dev Tools UI
- toggle "Show Chunk Bounds" to display/hide grid lines


------
https://chatgpt.com/codex/tasks/task_e_68ad23a603588322981800cde3b079a9