### PR TITLE
fix: make resource bodies static and immovable

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -223,7 +223,7 @@ export default class MainScene extends Phaser.Scene {
             maxSize: 32,
         });
         this.meleeHits = this.physics.add.group();
-        this.resources = this.physics.add.group();
+        this.resources = this.physics.add.staticGroup();
         this.droppedItems = this.add.group();
         this._dropCleanupEvent = this.time.addEvent({
             delay: 1000,

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -128,6 +128,8 @@ export default function createResourceSystem(scene) {
         if (def.tags?.includes('bush')) trunk.setData('bush', true);
         if (trunk.body) {
             trunk.body.setAllowGravity(false);
+            trunk.body.setImmovable(true);
+            trunk.body.moves = false;
         }
         return trunk;
     }


### PR DESCRIPTION
Summary:
- Use static physics group for resources and mark trunks immovable to prevent unintended movement.

Technical Approach:
- scenes/MainScene.js#create
- systems/resourceSystem.js#_createResource

Performance:
- Static bodies remove runtime updates and allocations.

Risks & Rollback:
- Resource collisions might need adjustment; revert commit if issues arise.

QA Steps:
- `npm test`
- Launch game and verify resource objects remain static when colliding.


------
https://chatgpt.com/codex/tasks/task_e_68ad267a3e4083229597d7f97d609068