### PR TITLE
perf(world): limit chunk zombies & active radius

### DIFF
--- a/systems/worldGen/ChunkManager.js
+++ b/systems/worldGen/ChunkManager.js
@@ -2,7 +2,7 @@
 // Tracks player-centric chunks and emits activation/deactivation events.
 export const CHUNK_WIDTH = 400;
 export const CHUNK_HEIGHT = 300;
-const ACTIVE_RADIUS = 2; // chunks around player kept active
+const ACTIVE_RADIUS = 1; // chunks around player kept active
 
 export default class ChunkManager {
     constructor(scene, player) {


### PR DESCRIPTION
Summary:
- Gate chunk-based zombie spawns by day/night chance and global cap
- Reduce ChunkManager ACTIVE_RADIUS to keep fewer chunks active

Technical Approach:
- systems/combatSystem.js#onChunkActivate reads WORLD_GEN spawn chances, enforces max active zombies, and spawns at most one
- systems/worldGen/ChunkManager.js lowers ACTIVE_RADIUS to 1

Performance:
- Avoids excessive zombie creation and per-frame overhead from distant chunks

Risks & Rollback:
- Could under-spawn zombies; revert commit 00eb26b if spawn rates feel too low

QA Steps:
- Run `npm test`
- Move the player across chunk boundaries; verify at most one zombie spawns per new chunk and total zombies never exceed nightWaves.maxCount


------
https://chatgpt.com/codex/tasks/task_e_68ad267b76488322804bb17bdea40a0f