### PR TITLE
feat: enable right-click resource pickup

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -129,6 +129,20 @@ export default function createResourceSystem(scene) {
         if (trunk.body) {
             trunk.body.setAllowGravity(false);
         }
+
+        if (def.collectible) {
+            trunk.setInteractive();
+            trunk.on('pointerdown', (pointer) => {
+                if (!pointer?.rightButtonDown || !pointer.rightButtonDown()) return;
+                const dx = scene.player.x - trunk.x;
+                const dy = scene.player.y - trunk.y;
+                if (dx * dx + dy * dy > 40 * 40) return;
+                if (def.givesItem) {
+                    scene.addItemToInventory(def.givesItem, def.giveAmount ?? 1);
+                }
+                trunk.destroy();
+            });
+        }
         return trunk;
     }
 


### PR DESCRIPTION
Summary:
- allow collectible resources to be picked up with a right-click within 40px
- auto-pickup still triggers resource pointerdown when holding right-click nearby

Technical Approach:
- systems/resourceSystem.js `_createResource` adds interactive + pointerdown for `def.collectible`
- scenes/MainScene.js `_attemptAutoPickup` retains `pointerdown` emission on nearby resources

Performance:
- no per-frame allocations; handlers bound once per resource

Risks & Rollback:
- misconfigured resource defs may not yield items; revert commit to undo

QA Steps:
- start game and find a small rock
- right-click within ~40px: rock disappears and item added to inventory
- hold right-click and move near rock: auto-pickup collects it


------
https://chatgpt.com/codex/tasks/task_e_68ad267cac0c8322805d635ec44a7b56