### PR TITLE
feat: make Dev Tools screen scrollable

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -128,7 +128,15 @@ export default class DevUIScene extends Phaser.Scene {
         this._makeButton(camW - 160, 10, 150, 30, '◀ Return', () => this._goBack(), 2);
 
         // Content root
+        const viewH = camH - 54 - 24;
         this.content = this.add.container(0, 54).setDepth(1);
+
+        // Clip content to viewport so we can scroll
+        const maskShape = this.add.rectangle(0, 54, camW, viewH, 0xffffff, 0)
+            .setOrigin(0, 0)
+            .setScrollFactor(0)
+            .setDepth(1);
+        this.content.setMask(maskShape.createGeometryMask());
 
         let y = 0;
         y = this._sectionTitle('Cheats', y);


### PR DESCRIPTION
## Summary
- clip Dev Tools panel so it can scroll within viewport

## Technical Approach
- add geometry mask in `scenes/DevUIScene.js` and compute view height

## Performance
- mask is static and only adjusts container position on scroll; no per-frame allocations

## Risks & Rollback
- mask dimensions might need tuning for different resolutions; revert commit if layout issues occur

## QA Steps
- open Dev Mode
- use mouse wheel to scroll through all Dev Tools options
- ensure dropdown lists still scroll independently

------
https://chatgpt.com/codex/tasks/task_e_68ad26c4e38c83228706db4af98121bd