### PR TITLE
fix: guard static resource body methods

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -154,9 +154,9 @@ export default function createResourceSystem(scene) {
         trunk.setData('blocking', blocking);
         if (def.tags?.includes('bush')) trunk.setData('bush', true);
         if (trunk.body) {
-            trunk.body.setAllowGravity(false);
-            trunk.body.setImmovable(true);
-            trunk.body.moves = false;
+            if (trunk.body.setAllowGravity) trunk.body.setAllowGravity(false);
+            if (trunk.body.setImmovable) trunk.body.setImmovable(true);
+            if ('moves' in trunk.body) trunk.body.moves = false;
         }
 
         if (def.collectible) {


### PR DESCRIPTION
## Summary
- prevent resource spawn crash by checking for physics methods on static bodies

## Technical Approach
- updated `systems/resourceSystem.js` `_createResource` to guard `setAllowGravity`, `setImmovable`, and `moves` assignments

## Performance
- no per-frame allocations introduced; only a few conditional checks during resource creation

## Risks & Rollback
- low risk: only affects resource spawns; revert commit `c74c092` if issues arise

## QA Steps
- run `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad289db33c8322b5767955b6e892b9