### PR TITLE
feat: spawn player at world center

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -133,8 +133,10 @@ export default class MainScene extends Phaser.Scene {
         this.inputSystem = createInputSystem(this);
 
         // Player
+        const startX = WORLD_GEN.world.width / 2;
+        const startY = WORLD_GEN.world.height / 2;
         this.player = this.physics.add
-            .sprite(400, 300, 'player')
+            .sprite(startX, startY, 'player')
             .setScale(0.5)
             .setDepth(900)
             .setCollideWorldBounds(true);


### PR DESCRIPTION
Summary:
- Spawn player at world center from world config.

Technical Approach:
- scenes/MainScene.js: derive startX and startY from WORLD_GEN.world dimensions when creating the player.

Performance:
- Calculates spawn coordinates once during scene creation; no per-frame allocations.

Risks & Rollback:
- Misconfigured world dimensions could spawn player off-map; revert commit c8545f2 if needed.

QA Steps:
- Launch the game.
- Confirm player appears in the middle of the world.


------
https://chatgpt.com/codex/tasks/task_e_68ad2c294008832299b6432a9dd4b838