### PR TITLE
feat: add world body shapes for resources

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -157,6 +157,31 @@ export default function createResourceSystem(scene) {
             if (trunk.body.setAllowGravity) trunk.body.setAllowGravity(false);
             if (trunk.body.setImmovable) trunk.body.setImmovable(true);
             if ('moves' in trunk.body) trunk.body.moves = false;
+            const bodyDef = def.world?.body;
+            if (bodyDef) {
+                const scaleBody = bodyDef.useScale ? scale : 1;
+                let anchorX = 0;
+                let anchorY = 0;
+                if (bodyDef.anchor === 'bottomCenter') {
+                    anchorX = trunk.width * scale * 0.5;
+                    anchorY = trunk.height * scale;
+                } else if (bodyDef.anchor === 'topCenter') {
+                    anchorX = trunk.width * scale * 0.5;
+                    anchorY = 0;
+                }
+                const cx = anchorX + (bodyDef.offsetX || 0) * scaleBody;
+                const cy = anchorY + (bodyDef.offsetY || 0) * scaleBody;
+                if (bodyDef.kind === 'circle' && trunk.body.setCircle) {
+                    const radius = bodyDef.radius * scaleBody;
+                    trunk.body.setCircle(radius, cx - radius, cy - radius);
+                } else if (bodyDef.kind === 'rect') {
+                    const width = bodyDef.width * scaleBody;
+                    const height = bodyDef.height * scaleBody;
+                    if (trunk.body.setSize) trunk.body.setSize(width, height);
+                    if (trunk.body.setOffset)
+                        trunk.body.setOffset(cx - width / 2, cy - height / 2);
+                }
+            }
         }
 
         if (def.collectible) {


### PR DESCRIPTION
## Summary
- apply circle and rectangle physics bodies from resource definitions

## Technical Approach
- update `_createResource` in `systems/resourceSystem.js` to read `def.world.body`
- support `circle` via `setCircle` and `rect` via `setSize`/`setOffset`

## Performance
- body calculations occur once during resource spawn; no per-frame allocations

## Risks & Rollback
- incorrect body configs could misalign collisions; revert commit if issues arise

## QA Steps
- build and run the game
- spawn resources with `circle` and `rect` body definitions
- ensure blocking resources stop the player
- verify collectible resources remain interactive


------
https://chatgpt.com/codex/tasks/task_e_68ad323614548322accb9ea76d94ebae