### PR TITLE
feat: deterministic chunk entity spawning

### DIFF
--- a/chunk/ChunkSpawner.js
+++ b/chunk/ChunkSpawner.js
@@ -1,14 +1,82 @@
+import { CHUNK_WIDTH, CHUNK_HEIGHT } from '../systems/worldGen/ChunkManager.js';
+
 export default class ChunkSpawner {
-    constructor(rng) {
-        this.rng = rng;
-        // TODO: seedable RNG for deterministic spawning
+    constructor(seed = 0) {
+        this.seed = seed;
+        this._active = new Map();
     }
 
+    /**
+     * Spawn deterministic per-chunk entities such as zombies.
+     * @param {Phaser.Scene} scene
+     * @param {{chunkX:number, chunkY:number, entities?:Array}} chunkMeta
+     * @returns {Array} list of spawned entities
+     */
     spawn(scene, chunkMeta) {
-        // TODO: spawn entities for the chunk
+        const { chunkX, chunkY } = chunkMeta || {};
+        const key = `${chunkX},${chunkY}`;
+        if (this._active.has(key)) return this._active.get(key);
+
+        const rng = new Phaser.Math.RandomDataGenerator([
+            this.seed,
+            chunkX,
+            chunkY,
+        ]);
+        const spawned = [];
+
+        if (Array.isArray(chunkMeta?.entities)) {
+            for (const ent of chunkMeta.entities) {
+                if (ent.type === 'zombie') {
+                    const z = scene.spawnZombie(ent.zombieType || 'walker', {
+                        x: ent.x,
+                        y: ent.y,
+                    });
+                    if (z) spawned.push(z);
+                }
+            }
+        } else {
+            const chance = 0.25;
+            const maxCount = 3;
+            const count = rng.frac() < chance ? rng.between(1, maxCount) : 0;
+            for (let i = 0; i < count; i++) {
+                const x = rng.between(
+                    chunkX * CHUNK_WIDTH,
+                    chunkX * CHUNK_WIDTH + CHUNK_WIDTH,
+                );
+                const y = rng.between(
+                    chunkY * CHUNK_HEIGHT,
+                    chunkY * CHUNK_HEIGHT + CHUNK_HEIGHT,
+                );
+                const z = scene.spawnZombie('walker', { x, y });
+                if (z) {
+                    z.setData('chunkX', chunkX);
+                    z.setData('chunkY', chunkY);
+                    spawned.push(z);
+                }
+            }
+        }
+
+        this._active.set(key, spawned);
+        return spawned;
     }
 
+    /**
+     * Despawn any entities tracked for the given chunk.
+     * @param {Phaser.Scene} scene
+     * @param {{chunkX:number, chunkY:number}} chunkMeta
+     * @returns {number} number of entities removed
+     */
     despawn(scene, chunkMeta) {
-        // TODO: remove entities when chunk is deactivated
+        const { chunkX, chunkY } = chunkMeta || {};
+        const key = `${chunkX},${chunkY}`;
+        const list = this._active.get(key);
+        if (list) {
+            for (const obj of list) {
+                if (obj && obj.destroy) obj.destroy();
+            }
+            this._active.delete(key);
+            return list.length;
+        }
+        return 0;
     }
 }

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -8,6 +8,7 @@ import createCombatSystem from '../systems/combatSystem.js';
 import createDayNightSystem from '../systems/dayNightSystem.js';
 import createResourceSystem from '../systems/resourceSystem.js';
 import createInputSystem from '../systems/inputSystem.js';
+import ChunkSpawner from '../chunk/ChunkSpawner.js';
 
 export default class MainScene extends Phaser.Scene {
     constructor() {
@@ -240,6 +241,18 @@ export default class MainScene extends Phaser.Scene {
         });
 
         this.chunkManager = new ChunkManager(this, this.player);
+
+        this.chunkSpawner = new ChunkSpawner();
+        const _onChunkActivate = ({ chunkX, chunkY }) =>
+            this.chunkSpawner.spawn(this, { chunkX, chunkY });
+        const _onChunkDeactivate = ({ chunkX, chunkY }) =>
+            this.chunkSpawner.despawn(this, { chunkX, chunkY });
+        this.events.on('chunk:activate', _onChunkActivate);
+        this.events.on('chunk:deactivate', _onChunkDeactivate);
+        this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+            this.events.off('chunk:activate', _onChunkActivate);
+            this.events.off('chunk:deactivate', _onChunkDeactivate);
+        });
 
         // Physics interactions
         this.physics.add.overlap(

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -3,59 +3,9 @@
 import { ITEM_DB } from '../data/itemDatabase.js';
 import ZOMBIES from '../data/zombieDatabase.js';
 import DevTools from './DevTools.js';
-import { CHUNK_WIDTH, CHUNK_HEIGHT } from './worldGen/ChunkManager.js';
 import { WORLD_GEN } from '../data/worldGenConfig.js';
 
 export default function createCombatSystem(scene) {
-    const chunkZombies = new Map();
-
-    const onChunkActivate = ({ chunkX, chunkY, rng }) => {
-        const key = `${chunkX},${chunkY}`;
-        if (chunkZombies.has(key)) return;
-        chunkZombies.set(key, []);
-
-        const max = WORLD_GEN.spawns.zombie.nightWaves.maxCount;
-        if (scene.zombies.countActive(true) >= max) return;
-
-        const chance =
-            scene.phase === 'night'
-                ? WORLD_GEN.spawns.zombie.nightTrickle.chance
-                : WORLD_GEN.spawns.zombie.day.chance;
-        if (rng.frac() > chance) return;
-
-        const x = rng.between(
-            chunkX * CHUNK_WIDTH,
-            chunkX * CHUNK_WIDTH + CHUNK_WIDTH,
-        );
-        const y = rng.between(
-            chunkY * CHUNK_HEIGHT,
-            chunkY * CHUNK_HEIGHT + CHUNK_HEIGHT,
-        );
-        const z = spawnZombie('walker', { x, y });
-        if (z) {
-            z.setData('chunkX', chunkX);
-            z.setData('chunkY', chunkY);
-            chunkZombies.get(key).push(z);
-        }
-    };
-
-    const onChunkDeactivate = ({ chunkX, chunkY }) => {
-        const key = `${chunkX},${chunkY}`;
-        const list = chunkZombies.get(key);
-        if (list) {
-            for (const z of list) if (z && z.destroy) z.destroy();
-            chunkZombies.delete(key);
-        }
-    };
-
-    if (scene?.events?.on) {
-        scene.events.on('chunk:activate', onChunkActivate);
-        scene.events.on('chunk:deactivate', onChunkDeactivate);
-        scene.events.once('shutdown', () => {
-            scene.events.off('chunk:activate', onChunkActivate);
-            scene.events.off('chunk:deactivate', onChunkDeactivate);
-        });
-    }
     // ----- Hit Handling -----
     function handleMeleeHit(hit, zombie) {
         if (!hit || !zombie || !zombie.active) return;

--- a/test/chunk/ChunkSpawner.test.js
+++ b/test/chunk/ChunkSpawner.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ChunkSpawner from '../../chunk/ChunkSpawner.js';
+
+class RNG {
+    constructor(seeds) {
+        this.state = seeds.reduce((s, v) => s + (v || 0), 0);
+    }
+    _next() {
+        const x = Math.sin(this.state++) * 10000;
+        return x - Math.floor(x);
+    }
+    frac() {
+        return this._next();
+    }
+    between(min, max) {
+        return Math.floor(this._next() * (max - min)) + min;
+    }
+}
+
+globalThis.Phaser = { Math: { RandomDataGenerator: RNG } };
+
+test('chunk spawner is deterministic per chunk', () => {
+    const spawner = new ChunkSpawner(42);
+    const spawned = [];
+    const destroyed = [];
+    const scene = {
+        spawnZombie: (type, pos) => {
+            const obj = {
+                ...pos,
+                setData() {},
+                destroy() {
+                    destroyed.push(pos);
+                },
+            };
+            spawned.push(obj);
+            return obj;
+        },
+    };
+    const meta = { chunkX: 1, chunkY: 2 };
+    const first = spawner
+        .spawn(scene, meta)
+        .map((z) => ({ x: z.x, y: z.y }));
+    spawner.despawn(scene, meta);
+    assert.equal(destroyed.length, first.length);
+    spawned.length = 0;
+    destroyed.length = 0;
+    const second = spawner
+        .spawn(scene, meta)
+        .map((z) => ({ x: z.x, y: z.y }));
+    assert.deepEqual(first, second);
+});


### PR DESCRIPTION
Summary:
- seed chunk-based spawns for repeatable zombies and future entities
- drive ChunkSpawner via MainScene chunk events and prune old combat hooks

Technical Approach:
- chunk/ChunkSpawner.js spawn/despawn with seeded RNG
- scenes/MainScene.js wires chunk activate/deactivate to ChunkSpawner
- systems/combatSystem.js drops legacy chunk spawn handlers
- test/chunk/ChunkSpawner.test.js covers deterministic behaviour

Performance:
- spawns occur only on chunk activate/deactivate, avoiding per-frame allocations

Risks & Rollback:
- incorrect event wiring could leave zombies orphaned; revert commit to restore prior behaviour

QA Steps:
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad3239edc0832284ab07a34e9e11d1