### PR TITLE
feat: add chunk passability grid

### DIFF
--- a/chunk/ChunkPathGrid.js
+++ b/chunk/ChunkPathGrid.js
@@ -1,4 +1,34 @@
+import { CHUNK_WIDTH, CHUNK_HEIGHT } from '../systems/worldGen/ChunkManager.js';
+
+const CELL_SIZE = 20;
+const COLS = Math.ceil(CHUNK_WIDTH / CELL_SIZE);
+const ROWS = Math.ceil(CHUNK_HEIGHT / CELL_SIZE);
+// 0 = passable, 1 = blocked
+
 export function getChunkPathGrid(chunkMeta) {
-    // TODO: expose chunk-level pathfinding grid
-    return null;
+    const grid = new Uint8Array(COLS * ROWS);
+    const list = chunkMeta?.resources;
+    if (Array.isArray(list)) {
+        const offsetX = (chunkMeta?.chunkX || 0) * CHUNK_WIDTH;
+        const offsetY = (chunkMeta?.chunkY || 0) * CHUNK_HEIGHT;
+        for (let i = 0; i < list.length; i++) {
+            const r = list[i];
+            const blocking =
+                typeof r?.getData === 'function' ? r.getData('blocking') : r?.blocking;
+            if (!blocking) continue;
+            const x = (r.x || 0) - offsetX;
+            const y = (r.y || 0) - offsetY;
+            const c = (x / CELL_SIZE) | 0;
+            const rIdx = (y / CELL_SIZE) | 0;
+            if (c >= 0 && c < COLS && rIdx >= 0 && rIdx < ROWS) {
+                grid[rIdx * COLS + c] = 1;
+            }
+        }
+    }
+    return {
+        width: COLS,
+        height: ROWS,
+        cellSize: CELL_SIZE,
+        data: grid,
+    };
 }

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -35,6 +35,8 @@ export default function createCombatSystem(scene) {
         if (z) {
             z.setData('chunkX', chunkX);
             z.setData('chunkY', chunkY);
+            const grid = scene.chunkPathGrids?.get(key);
+            if (grid) z.setData('pathGrid', grid);
             chunkZombies.get(key).push(z);
         }
     };

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -4,6 +4,7 @@ import { WORLD_GEN } from '../data/worldGenConfig.js';
 import { DESIGN_RULES } from '../data/designRules.js';
 import { RESOURCE_DB } from '../data/resourceDatabase.js';
 import { CHUNK_WIDTH, CHUNK_HEIGHT } from './worldGen/ChunkManager.js';
+import { getChunkPathGrid } from '../chunk/ChunkPathGrid.js';
 
 export default function createResourceSystem(scene) {
     const chunkResources = new Map();
@@ -24,6 +25,11 @@ export default function createResourceSystem(scene) {
             );
         }
         chunkResources.set(key, list);
+        if (!scene.chunkPathGrids) scene.chunkPathGrids = new Map();
+        scene.chunkPathGrids.set(
+            key,
+            getChunkPathGrid({ chunkX, chunkY, resources: list }),
+        );
         _ensureColliders();
     };
 
@@ -34,6 +40,7 @@ export default function createResourceSystem(scene) {
             for (const obj of list) obj.destroy();
             chunkResources.delete(key);
         }
+        if (scene.chunkPathGrids) scene.chunkPathGrids.delete(key);
     };
 
     scene.events.on('chunk:activate', onActivate);


### PR DESCRIPTION
Summary:
- derive passability grid from chunk resources and surface to AI for path planning

Technical Approach:
- build chunk-level grid in chunk/ChunkPathGrid.js
- generate grids during resource spawning and store on scene
- attach chunk grid to zombies upon spawn

Performance:
- grid computed once per chunk activation; no per-frame allocations

Risks & Rollback:
- if path grid causes unexpected AI behavior, revert by removing ChunkPathGrid usage in resources/combat systems

QA Steps:
- run `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad323b83188322821c0877a951f608