### PR TITLE
feat: add rock top overlay

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -152,6 +152,20 @@ export default function createResourceSystem(scene) {
 
         const blocking = !!def.blocking;
         trunk.setData('blocking', blocking);
+        if (blocking && def.tags?.includes('rock')) {
+            const frameW = trunk.width;
+            const frameH = trunk.height;
+            const topH = frameH * 0.5;
+            const top = scene.add
+                .image(x, y, texKey)
+                .setOrigin(originX, originY)
+                .setScale(scale)
+                .setDepth((scene.player?.depth ?? 900) + 2)
+                .setCrop(0, 0, frameW, topH);
+            trunk.setCrop(0, topH, frameW, frameH - topH);
+            trunk.setData('topSprite', top);
+            trunk.once('destroy', () => top.destroy());
+        }
         if (def.tags?.includes('bush')) trunk.setData('bush', true);
         if (trunk.body) {
             if (trunk.body.setAllowGravity) trunk.body.setAllowGravity(false);


### PR DESCRIPTION
Summary:
- Crop top half of blocking rocks into a separate sprite so player renders behind it.

Technical Approach:
- systems/resourceSystem.js: in _createResource, create a cropped overlay image above player depth; destroy overlay when the rock is removed.

Performance:
- Overlay created once per rock and cleaned up on destroy; no per-frame allocations.

Risks & Rollback:
- Potential layering issues if resource definitions change; revert commit f8d42f7 if needed.

QA Steps:
- Spawn a blocking rock.
- Verify player appears behind rock top but in front of base.
- Remove rock and confirm top overlay disappears.
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3238e8d483228213195a40e1bbd8