### PR TITLE
fix(resource): revert to 1213f78 spawn logic

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -225,7 +225,7 @@ export default class MainScene extends Phaser.Scene {
             maxSize: 32,
         });
         this.meleeHits = this.physics.add.group();
-        this.resources = this.physics.add.staticGroup();
+        this.resources = this.physics.add.group();
         this.droppedItems = this.add.group();
         this._dropCleanupEvent = this.time.addEvent({
             delay: 1000,
@@ -238,6 +238,9 @@ export default class MainScene extends Phaser.Scene {
         this.events.once(Phaser.Scenes.Events.DESTROY, () => {
             this._dropCleanupEvent?.remove(false);
         });
+
+        // Spawn resources from WORLD_GEN (all resource groups)
+        this.spawnAllResources();
 
         this.chunkManager = new ChunkManager(this, this.player);
 
@@ -352,6 +355,10 @@ export default class MainScene extends Phaser.Scene {
     // ==========================
     // Resource spawning (DB-driven)
     // ==========================
+
+    spawnAllResources() {
+        return this.resourceSystem.spawnAllResources();
+    }
 
     addItemToInventory(id, qty = 1, _where = 'inventory') {
         const inv = this.uiScene?.inventory;

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -1,49 +1,18 @@
 // systems/resourceSystem.js
-// Handles world resource spawning via chunk events.
+// Handles world resource spawning in a Phaser-agnostic way.
 import { WORLD_GEN } from '../data/worldGenConfig.js';
 import { DESIGN_RULES } from '../data/designRules.js';
 import { RESOURCE_DB } from '../data/resourceDatabase.js';
-import { CHUNK_WIDTH, CHUNK_HEIGHT } from './worldGen/ChunkManager.js';
 
 export default function createResourceSystem(scene) {
-    const chunkResources = new Map();
-
-    const onActivate = ({ chunkX, chunkY, rng }) => {
-        const key = `${chunkX},${chunkY}`;
-        if (chunkResources.has(key)) return;
+    // ----- Public API -----
+    function spawnAllResources() {
         const all = WORLD_GEN?.spawns?.resources;
         if (!all) return;
-        const minX = chunkX * CHUNK_WIDTH;
-        const minY = chunkY * CHUNK_HEIGHT;
-        const maxX = minX + CHUNK_WIDTH;
-        const maxY = minY + CHUNK_HEIGHT;
-        const list = [];
-        for (const [gk, cfg] of Object.entries(all)) {
-            list.push(
-                ..._spawnGroup(gk, cfg, rng, minX, maxX, minY, maxY, chunkX, chunkY),
-            );
-        }
-        chunkResources.set(key, list);
-        _ensureColliders();
-    };
 
-    const onDeactivate = ({ chunkX, chunkY }) => {
-        const key = `${chunkX},${chunkY}`;
-        const list = chunkResources.get(key);
-        if (list) {
-            for (const obj of list) obj.destroy();
-            chunkResources.delete(key);
-        }
-    };
+        for (const [key, cfg] of Object.entries(all))
+            _spawnResourceGroup(key, cfg);
 
-    scene.events.on('chunk:activate', onActivate);
-    scene.events.on('chunk:deactivate', onDeactivate);
-    scene.events.once('shutdown', () => {
-        scene.events.off('chunk:activate', onActivate);
-        scene.events.off('chunk:deactivate', onDeactivate);
-    });
-
-    function _ensureColliders() {
         if (!scene._resourcesCollider) {
             scene._resourcesCollider = scene.physics.add.collider(
                 scene.player,
@@ -53,6 +22,7 @@ export default function createResourceSystem(scene) {
                 scene,
             );
         }
+
         if (!scene._bushSlowOverlap) {
             const markBush = (ent, obj) => {
                 if (obj.getData('bush')) ent._inBush = true;
@@ -83,98 +53,431 @@ export default function createResourceSystem(scene) {
         }
     }
 
-    function _spawnGroup(groupKey, groupCfg, rng, minX, maxX, minY, maxY, chunkX, chunkY) {
-        const variants = Array.isArray(groupCfg?.variants) ? groupCfg.variants : null;
-        if (!variants || variants.length === 0) return [];
+    // ----- Internal Helpers -----
+    function _spawnResourceGroup(groupKey, groupCfg) {
+        const variants = Array.isArray(groupCfg?.variants)
+            ? groupCfg.variants
+            : null;
+        if (!variants || variants.length === 0) return;
+
+        const maxActive =
+            groupCfg.maxActive ??
+            Phaser.Math.Between(
+                groupCfg.minCount ?? 8,
+                groupCfg.maxCount ?? 12,
+            );
+        const minSpacing = groupCfg.minSpacing ?? 48;
+        const respawnMin = groupCfg.respawnDelayMs?.min ?? 5000;
+        const respawnMax = groupCfg.respawnDelayMs?.max ?? 7000;
+        const clusterMin = groupCfg.clusterMin ?? 3;
+        const clusterMax = groupCfg.clusterMax ?? 6;
         const totalWeight = variants.reduce((s, v) => s + (v.weight || 0), 0);
-        const totalChunks =
-            (WORLD_GEN.world.width / CHUNK_WIDTH) *
-            (WORLD_GEN.world.height / CHUNK_HEIGHT);
-        const countPerChunk = Math.max(
-            1,
-            Math.floor((groupCfg.maxActive || 0) / totalChunks),
-        );
-        const minSpacing = groupCfg.minSpacing || 0;
-        const minSpacingSq = minSpacing * minSpacing;
-        const results = [];
-        for (let i = 0; i < countPerChunk; i++) {
-            let r = rng.frac() * totalWeight;
-            let id = variants[0].id;
-            for (const v of variants) {
-                r -= v.weight || 0;
-                if (r <= 0) {
-                    id = v.id;
-                    break;
-                }
+
+        const w = scene.sys.game.config.width;
+        const h = scene.sys.game.config.height;
+        const minX = 0,
+            maxX = w,
+            minY = 0,
+            maxY = h;
+
+        const tooClose = (x, y, w, h) => {
+            const children = scene.resources.getChildren();
+            for (let i = 0; i < children.length; i++) {
+                const c = children[i];
+                if (!c.active) continue;
+                const halfW = (c.displayWidth + w) * 0.5;
+                const halfH = (c.displayHeight + h) * 0.5;
+                const dx = c.x - x;
+                const dy = c.y - y;
+                if (Math.abs(dx) < halfW && Math.abs(dy) < halfH) return true;
             }
-            const def = RESOURCE_DB[id];
-            if (!def) continue;
-            let x = 0;
-            let y = 0;
-            let valid = false;
-            for (let attempt = 0; attempt < 4 && !valid; attempt++) {
-                x = rng.between(minX, maxX);
-                y = rng.between(minY, maxY);
-                valid = true;
-                if (minSpacing > 0) {
-                    const existing = scene.resources.getChildren();
-                    for (let j = 0; j < existing.length; j++) {
-                        const obj = existing[j];
-                        const dx = obj.x - x;
-                        const dy = obj.y - y;
-                        if (dx * dx + dy * dy < minSpacingSq) {
-                            valid = false;
+            return false;
+        };
+
+        const pickVariantId = () => {
+            let r = Math.random() * totalWeight;
+            for (let v of variants) {
+                r -= v.weight || 0;
+                if (r <= 0) return v.id;
+            }
+            return variants[0].id;
+        };
+
+        const createResourceAt = (id, def, x, y) => {
+            const originX = def.world?.origin?.x ?? 0.5;
+            const originY = def.world?.origin?.y ?? 0.5;
+            const scale = def.world?.scale ?? 1;
+            const texKey = def.world?.textureKey || id;
+
+            const trunk = scene.resources
+                .create(x, y, texKey)
+                .setOrigin(originX, originY)
+                .setScale(scale)
+                .setDepth(def.trunkDepth ?? def.depth ?? 5);
+
+            const blocking = !!def.blocking;
+            trunk.setData('blocking', blocking);
+
+            if (blocking && def.tags?.includes('rock')) {
+                const frameW = trunk.width;
+                const frameH = trunk.height;
+                const topH = frameH * 0.5;
+                const top = scene.add
+                    .image(x, y, texKey)
+                    .setOrigin(originX, originY)
+                    .setScale(scale)
+                    .setDepth((scene.player?.depth ?? 900) + 2)
+                    .setCrop(0, 0, frameW, topH);
+                trunk.setCrop(0, topH, frameW, frameH - topH);
+                trunk.setData('topSprite', top);
+                trunk.once('destroy', () => top.destroy());
+            }
+
+            if (def.tags?.includes('bush')) trunk.setData('bush', true);
+
+            const bodyCfg = def.world?.body;
+            if (trunk.body) {
+                trunk.body.setAllowGravity(false);
+
+                if (bodyCfg) {
+                    const frameW = trunk.width;
+                    const frameH = trunk.height;
+                    const dispW = trunk.displayWidth;
+                    const dispH = trunk.displayHeight;
+
+                    const scaleX = trunk.scaleX || 1;
+                    const scaleY = trunk.scaleY || 1;
+                    const useScale = !!bodyCfg.useScale;
+
+                    let bw, bh, br;
+                    if (bodyCfg.kind === 'circle') {
+                        br = useScale
+                            ? bodyCfg.radius * scaleX
+                            : bodyCfg.radius;
+                        bw = bh = 2 * br;
+                    } else {
+                        bw = useScale ? bodyCfg.width * scaleX : bodyCfg.width;
+                        bh = useScale
+                            ? bodyCfg.height * scaleY
+                            : bodyCfg.height;
+                    }
+
+                    const anchorSpaceW = useScale ? dispW : frameW;
+                    const anchorSpaceH = useScale ? dispH : frameH;
+
+                    const anchor = bodyCfg.anchor || 'topLeft';
+                    let baseX = 0,
+                        baseY = 0;
+                    switch (anchor) {
+                        case 'center':
+                            baseX = (anchorSpaceW - bw) * 0.5;
+                            baseY = (anchorSpaceH - bh) * 0.5;
                             break;
+                        case 'topCenter':
+                            baseX = (anchorSpaceW - bw) * 0.5;
+                            baseY = 0;
+                            break;
+                        case 'bottomCenter':
+                            baseX = (anchorSpaceW - bw) * 0.5;
+                            baseY = anchorSpaceH - bh;
+                            break;
+                        case 'bottomLeft':
+                            baseX = 0;
+                            baseY = anchorSpaceH - bh;
+                            break;
+                        case 'topLeft':
+                        default:
+                            baseX = 0;
+                            baseY = 0;
+                            break;
+                    }
+
+                    const addX = useScale
+                        ? (bodyCfg.offsetX || 0) * scaleX
+                        : bodyCfg.offsetX || 0;
+                    const addY = useScale
+                        ? (bodyCfg.offsetY || 0) * scaleY
+                        : bodyCfg.offsetY || 0;
+                    const ox = baseX + addX;
+                    const oy = baseY + addY;
+
+                    if (bodyCfg.kind === 'circle') {
+                        trunk.body.setCircle(br, ox, oy);
+                    } else {
+                        trunk.body.setSize(bw, bh);
+                        trunk.body.setOffset(ox, oy);
+                    }
+                    trunk.body.setImmovable(blocking);
+                } else {
+                    if (blocking) {
+                        trunk.body.setImmovable(true);
+                    } else {
+                        if (trunk.getData('bush')) {
+                            const r =
+                                Math.min(
+                                    trunk.displayWidth,
+                                    trunk.displayHeight,
+                                ) * 0.45; // shrink hitbox by 10%
+                            const ox = trunk.displayWidth * 0.5 - r;
+                            const oy = trunk.displayHeight * 0.5 - r;
+                            trunk.body.setCircle(r, ox, oy);
+                        } else {
+                            trunk.body.setSize(trunk.displayWidth, trunk.displayHeight);
+                            trunk.body.setOffset(0, 0);
                         }
+                        trunk.body.setImmovable(true);
                     }
                 }
             }
-            if (!valid) continue;
-            const obj = _createResource(id, def, x, y);
-            obj.setData('chunkX', chunkX);
-            obj.setData('chunkY', chunkY);
-            results.push(obj);
-        }
-        return results;
-    }
 
-    function _createResource(id, def, x, y) {
-        const originX = def.world?.origin?.x ?? 0.5;
-        const originY = def.world?.origin?.y ?? 0.5;
-        const scale = def.world?.scale ?? 1;
-        const texKey = def.world?.textureKey || id;
+            const leavesCfg = def.world?.leaves;
+            if (leavesCfg) {
+                const frameW = trunk.width;
+                const frameH = trunk.height;
 
-        const trunk = scene.resources
-            .create(x, y, texKey)
-            .setOrigin(originX, originY)
-            .setScale(scale)
-            .setDepth(def.trunkDepth ?? def.depth ?? 5);
+                const lw = leavesCfg.width;
+                const lh = leavesCfg.height;
 
-        const blocking = !!def.blocking;
-        trunk.setData('blocking', blocking);
-        if (def.tags?.includes('bush')) trunk.setData('bush', true);
-        if (trunk.body) {
-            if (trunk.body.setAllowGravity) trunk.body.setAllowGravity(false);
-            if (trunk.body.setImmovable) trunk.body.setImmovable(true);
-            if ('moves' in trunk.body) trunk.body.moves = false;
-        }
-
-        if (def.collectible) {
-            trunk.setInteractive();
-            trunk.on('pointerdown', (pointer) => {
-                if (!pointer?.rightButtonDown || !pointer.rightButtonDown()) return;
-                const dx = scene.player.x - trunk.x;
-                const dy = scene.player.y - trunk.y;
-                if (dx * dx + dy * dy > 40 * 40) return;
-                if (def.givesItem) {
-                    scene.addItemToInventory(def.givesItem, def.giveAmount ?? 1);
+                const anchor = leavesCfg.anchor || 'topLeft';
+                let baseX = 0,
+                    baseY = 0;
+                switch (anchor) {
+                    case 'center':
+                        baseX = (frameW - lw) * 0.5;
+                        baseY = (frameH - lh) * 0.5;
+                        break;
+                    case 'topCenter':
+                        baseX = (frameW - lw) * 0.5;
+                        baseY = 0;
+                        break;
+                    case 'bottomCenter':
+                        baseX = (frameW - lw) * 0.5;
+                        baseY = frameH - lh;
+                        break;
+                    case 'bottomLeft':
+                        baseX = 0;
+                        baseY = frameH - lh;
+                        break;
+                    case 'topLeft':
+                    default:
+                        baseX = 0;
+                        baseY = 0;
+                        break;
                 }
-                trunk.destroy();
-            });
+
+                const addX = leavesCfg.offsetX || 0;
+                const addY = leavesCfg.offsetY || 0;
+                const cropX = baseX + addX;
+                const cropY = baseY + addY;
+
+                trunk.setCrop(0, cropY + lh, frameW, frameH - (cropY + lh));
+
+                const leaves = scene.add
+                    .image(x, y, texKey)
+                    .setOrigin(originX, originY)
+                    .setScale(scale)
+                    .setDepth(def.leavesDepth ?? def.depth ?? 5)
+                    .setCrop(cropX, cropY, lw, lh);
+
+                const dispW = trunk.displayWidth;
+                const dispH = trunk.displayHeight;
+                const scaleX = trunk.scaleX || 1;
+                const scaleY = trunk.scaleY || 1;
+                const useScale = !!leavesCfg.useScale;
+
+                const lwWorld = useScale ? lw * scaleX : lw;
+                const lhWorld = useScale ? lh * scaleY : lh;
+
+                const anchorSpaceW = useScale ? dispW : frameW;
+                const anchorSpaceH = useScale ? dispH : frameH;
+
+                switch (anchor) {
+                    case 'center':
+                        baseX = (anchorSpaceW - lwWorld) * 0.5;
+                        baseY = (anchorSpaceH - lhWorld) * 0.5;
+                        break;
+                    case 'topCenter':
+                        baseX = (anchorSpaceW - lwWorld) * 0.5;
+                        baseY = 0;
+                        break;
+                    case 'bottomCenter':
+                        baseX = (anchorSpaceW - lwWorld) * 0.5;
+                        baseY = anchorSpaceH - lhWorld;
+                        break;
+                    case 'bottomLeft':
+                        baseX = 0;
+                        baseY = anchorSpaceH - lhWorld;
+                        break;
+                    case 'topLeft':
+                    default:
+                        baseX = 0;
+                        baseY = 0;
+                        break;
+                }
+
+                const addXWorld = useScale ? addX * scaleX : addX;
+                const addYWorld = useScale ? addY * scaleY : addY;
+                const topLeftX = trunk.x - dispW * trunk.originX;
+                const topLeftY = trunk.y - dispH * trunk.originY;
+                const rect = new Phaser.Geom.Rectangle(
+                    topLeftX + baseX + addXWorld,
+                    topLeftY + baseY + addYWorld,
+                    lwWorld,
+                    lhWorld,
+                );
+
+                scene._treeLeaves = scene._treeLeaves || [];
+                const data = { leaves, rect };
+                scene._treeLeaves.push(data);
+                trunk.once('destroy', () => {
+                    leaves.destroy();
+                    const idx = scene._treeLeaves.indexOf(data);
+                    if (idx !== -1) scene._treeLeaves.splice(idx, 1);
+                });
+
+                if (!scene._treeLeavesUpdate) {
+                    const playerRect = new Phaser.Geom.Rectangle();
+                    scene._treeLeavesUpdate = () => {
+                        const pb = scene.player.body;
+                        playerRect.x = pb.x;
+                        playerRect.y = pb.y;
+                        playerRect.width = pb.width;
+                        playerRect.height = pb.height;
+                        for (const d of scene._treeLeaves) {
+                            const overlap =
+                                Phaser.Geom.Intersects.RectangleToRectangle(
+                                    playerRect,
+                                    d.rect,
+                                );
+                            d.leaves.setAlpha(overlap ? 0.5 : 1);
+                        }
+                    };
+                    scene.events.on('update', scene._treeLeavesUpdate);
+                    scene.events.once('shutdown', () => {
+                        scene.events.off('update', scene._treeLeavesUpdate);
+                        scene._treeLeaves = [];
+                        scene._treeLeavesUpdate = null;
+                    });
+                }
+            }
+
+            if (def.collectible) {
+                trunk.setInteractive();
+                trunk.on('pointerdown', (pointer) => {
+                    if (!pointer.rightButtonDown()) return;
+                    const pickupRange = 40;
+                    const d2 = Phaser.Math.Distance.Squared(
+                        scene.player.x,
+                        scene.player.y,
+                        trunk.x,
+                        trunk.y,
+                    );
+                    if (d2 > pickupRange * pickupRange) return;
+
+                    if (def.givesItem && scene.uiScene?.inventory) {
+                        scene.uiScene.inventory.addItem(
+                            def.givesItem,
+                            def.giveAmount || 1,
+                        );
+                    }
+                    trunk.destroy();
+                    scene.time.delayedCall(
+                        Phaser.Math.Between(respawnMin, respawnMax),
+                        () => {
+                            if (scene.resources.countActive(true) < maxActive)
+                                spawnCluster();
+                        },
+                    );
+                });
+            }
+        };
+
+        const spawnCluster = () => {
+            const baseId = pickVariantId();
+            const baseKey = baseId.replace(/[A-Za-z]$/, '');
+            const baseVariants = variants.filter((v) => v.id.startsWith(baseKey));
+            const baseTotalWeight = baseVariants.reduce(
+                (s, v) => s + (v.weight || 0),
+                0,
+            );
+            const pickBaseVariant = () => {
+                let r = Math.random() * baseTotalWeight;
+                for (const v of baseVariants) {
+                    r -= v.weight || 0;
+                    if (r <= 0) return v.id;
+                }
+                return baseVariants[0].id;
+            };
+
+            const firstId = pickBaseVariant();
+            const firstDef = RESOURCE_DB[firstId];
+            if (!firstDef) return 0;
+
+            const firstTex = scene.textures.get(
+                firstDef.world?.textureKey || firstId,
+            );
+            const src = firstTex.getSourceImage();
+            const scale = firstDef.world?.scale ?? 1;
+            const width = src.width * scale;
+            const height = src.height * scale;
+
+            let x,
+                y,
+                tries = 30;
+            do {
+                x = Phaser.Math.Between(minX, maxX);
+                y = Phaser.Math.Between(minY, maxY);
+                tries--;
+            } while (tries > 0 && tooClose(x, y, width, height));
+            if (tries <= 0) return 0;
+
+            createResourceAt(firstId, firstDef, x, y);
+            let spawned = 1;
+
+            const clusterCount = Phaser.Math.Between(clusterMin, clusterMax);
+            const radius =
+                groupCfg.clusterRadius ?? Math.max(width, height) * 1.1;
+            for (
+                let i = 1;
+                i < clusterCount && scene.resources.countActive(true) < maxActive;
+                i++
+            ) {
+                const id = pickBaseVariant();
+                const def = RESOURCE_DB[id];
+                if (!def) continue;
+
+                const tex = scene.textures.get(def.world?.textureKey || id);
+                const src2 = tex.getSourceImage();
+                const scale2 = def.world?.scale ?? 1;
+                const w = src2.width * scale2;
+                const h = src2.height * scale2;
+
+                let x2,
+                    y2,
+                    t2 = 10;
+                do {
+                    const ang = Phaser.Math.FloatBetween(0, Math.PI * 2);
+                    x2 = x + Math.cos(ang) * radius;
+                    y2 = y + Math.sin(ang) * radius;
+                    t2--;
+                } while (t2 > 0 && tooClose(x2, y2, w, h));
+                if (t2 <= 0) continue;
+                createResourceAt(id, def, x2, y2);
+                spawned++;
+            }
+
+            return spawned;
+        };
+
+        let spawned = 0,
+            attempts = 0;
+        while (spawned < maxActive && attempts < maxActive * 10) {
+            spawned += spawnCluster();
+            attempts++;
         }
-        return trunk;
     }
 
+    // ----- Dev Helpers -----
     function spawnWorldItem(id, pos) {
         const def = RESOURCE_DB[id];
         if (!def) return;
@@ -186,5 +489,5 @@ export default function createResourceSystem(scene) {
         obj.body.setAllowGravity(false);
     }
 
-    return { spawnWorldItem };
+    return { spawnAllResources, spawnWorldItem };
 }


### PR DESCRIPTION
## Summary
- restore global resource spawning using previous stable logic

## Technical Approach
- systems/resourceSystem.js: reintroduce spawnAllResources and cluster-based respawns
- scenes/MainScene.js: call spawnAllResources and switch resources group to dynamic

## Performance
- resource respawn uses scene.time.delayedCall without per-frame allocations

## Risks & Rollback
- global spawning may increase initial load; revert commit 7d52d07 if issues arise

## QA Steps
- `npm test`
- launch game and verify resources spawn and respawn after harvesting


------
https://chatgpt.com/codex/tasks/task_e_68ad3238001883228d7d8e423becdc32