### PR TITLE
feat: highlight dev-ui search suggestions and enforce limits

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -441,6 +441,8 @@ export default class DevUIScene extends Phaser.Scene {
                 this._renderDropdown();
             });
             rowC.on('pointerdown', () => {
+                this._enemy.resHL = i;
+                this._renderDropdown();
                 const sel = this._visibleDropdownItem(i);
                 if (sel) this._confirmTypeSelection(sel.name, true);
             });
@@ -534,23 +536,25 @@ export default class DevUIScene extends Phaser.Scene {
             const hlRect = this.add.rectangle(0, 0, listW - 4, rowH, 0xffffff, 0.08)
                 .setOrigin(0, 0)
                 .setDepth(3)
-                .setVisible(false)
-                .setInteractive({ useHandCursor: true });
+                .setVisible(false);
             const pre = this.add.text(2, 0, '', UI.font).setDepth(4);
             const mid = this.add.text(2, 0, '', { ...UI.font, fontStyle: 'bold' }).setDepth(4);
             const post = this.add.text(2, 0, '', UI.font).setDepth(4);
             rowC.add([hlRect, pre, mid, post]);
             rowC.setSize(listW - 4, rowH);
+            rowC.setInteractive(new Phaser.Geom.Rectangle(0, 0, listW - 4, rowH), Phaser.Geom.Rectangle.Contains);
             this._itemTypeRows.push(rowC);
             this._itemTypeDD.add(rowC);
             rowC._hlRect = hlRect; rowC._pre = pre; rowC._mid = mid; rowC._post = post;
             rowC._index = i;
 
-            hlRect.on('pointerover', () => {
+            rowC.on('pointerover', () => {
                 this._item.resHL = i;
                 this._renderItemDropdown();
             });
-            hlRect.on('pointerdown', () => {
+            rowC.on('pointerdown', () => {
+                this._item.resHL = i;
+                this._renderItemDropdown();
                 const sel = this._visibleItemDropdownItem(i);
                 if (sel) this._confirmItemSelection(sel.name, true);
             });
@@ -657,14 +661,16 @@ export default class DevUIScene extends Phaser.Scene {
                 const max = t.text.includes('.') ? 4 : 3;
                 if (t.text.length < max) {
                     const candidate = t.text + ev.key;
-                    let allow = true;
                     if (this._editing === this._gameSpeedText) {
-                        allow = parseFloat(candidate) <= 10;
+                        const num = parseFloat(candidate);
+                        t.setText(num > 10 ? '10' : candidate);
                     } else if (this._editing === this._itemCountText) {
                         const maxStack = this._item?.maxStack || 1;
-                        allow = parseInt(candidate, 10) <= maxStack;
+                        const num = parseInt(candidate, 10);
+                        t.setText(num > maxStack ? String(maxStack) : candidate);
+                    } else {
+                        t.setText(candidate);
                     }
-                    if (allow) t.setText(candidate);
                 }
                 return;
             }


### PR DESCRIPTION
Summary:
- highlight hovered search suggestions and keep selection when clicked or confirmed
- clamp item spawn counts to max stack and game speed to 10 during input

Technical Approach:
- scenes/DevUIScene.js: make dropdown rows interactive to update highlight; clamp numeric entry values on keydown

Performance:
- no per-frame allocations; only event-driven UI updates

Risks & Rollback:
- dropdown highlight logic could misbehave; revert commit 885069b to undo

QA Steps:
- open Dev UI
- search for an enemy or item and hover suggestions -> row highlight
- click or press Enter on a suggestion -> selection remains highlighted
- type item count beyond max stack -> value clamps to max
- type game speed >10 -> value clamps to 10

------
https://chatgpt.com/codex/tasks/task_e_68ad42df61ac8322bd089193153045f2