### PR TITLE
feat: halve auto pickup activation delay

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -436,7 +436,7 @@ export default class MainScene extends Phaser.Scene {
 
     _scheduleAutoPickup() {
         this._cancelAutoPickup();
-        this._autoPickupTimer = this.time.delayedCall(1000, () => {
+        this._autoPickupTimer = this.time.delayedCall(500, () => {
             if (this.isCharging || !this.input.activePointer.rightButtonDown())
                 return;
             this._autoPickupActive = true;


### PR DESCRIPTION
## Summary
- halve the auto pickup activation delay from 1s to 0.5s so held pickups engage sooner

## Technical Approach
- update `_scheduleAutoPickup` in `scenes/MainScene.js` to fire after 500ms

## Performance
- uses existing timer-based flow; no per-frame allocations introduced

## Risks & Rollback
- minimal; revert commit to restore previous 1s delay

## QA Steps
- Right-click and hold near a dropped item
- Confirm auto pickup begins after roughly 0.5 seconds


------
https://chatgpt.com/codex/tasks/task_e_68ae63e3f3e08322ab48a3bc73d85308