### PR TITLE
feat(world-gen): expand world map and exports

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -1,5 +1,5 @@
 // scenes/MainScene.js
-import { WORLD_GEN } from '../systems/world_gen/worldGenConfig.js';
+import { WORLD_GEN, spawn } from '../systems/world_gen/worldGenConfig.js';
 import { ITEM_DB } from '../data/itemDatabase.js';
 import ZOMBIES from '../data/zombieDatabase.js';
 import DevTools from '../systems/DevTools.js';
@@ -131,12 +131,18 @@ export default class MainScene extends Phaser.Scene {
         this.resourceSystem = createResourceSystem(this);
         this.inputSystem = createInputSystem(this);
 
+        // Expand world bounds to config size
+        this.physics.world.setBounds(0, 0, WORLD_GEN.world.width, WORLD_GEN.world.height);
+        this.cameras.main.setBounds(0, 0, WORLD_GEN.world.width, WORLD_GEN.world.height);
+
         // Player
         this.player = this.physics.add
-            .sprite(400, 300, 'player')
+            .sprite(spawn.x, spawn.y, 'player')
             .setScale(0.5)
             .setDepth(900)
             .setCollideWorldBounds(true);
+
+        this.cameras.main.startFollow(this.player);
 
         this.player._speedMult = 1;
         this.player._inBush = false;

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -73,8 +73,8 @@ export default function createResourceSystem(scene) {
         const clusterMax = groupCfg.clusterMax ?? 6;
         const totalWeight = variants.reduce((s, v) => s + (v.weight || 0), 0);
 
-        const w = scene.sys.game.config.width;
-        const h = scene.sys.game.config.height;
+        const w = WORLD_GEN.world.width;
+        const h = WORLD_GEN.world.height;
         const minX = 0,
             maxX = w,
             minY = 0,

--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -8,8 +8,15 @@ export const WORLD_GEN = {
   // World bounds / scale (future)
   // -----------------------------
   world: {
-    width: 1200,   // logical world width (px). You can expand later.
-    height: 900,   // logical world height (px).
+    width: 10000,  // logical world width (px). You can expand later.
+    height: 10000, // logical world height (px).
+  },
+
+  // -----------------------------
+  // Chunk settings (session only)
+  // -----------------------------
+  chunk: {
+    size: 500,
   },
 
   // -----------------------------
@@ -126,3 +133,9 @@ export const WORLD_GEN = {
     },
   },
 };
+
+// Center spawn point
+export const spawn = { x: 5000, y: 5000 };
+
+// Session-scoped metadata for procedural chunks
+export const chunkMetadata = new Map();


### PR DESCRIPTION
## Summary
- enlarge world bounds to 10000x10000 with 500px chunks
- expose center spawn and session chunk metadata
- apply new world size to MainScene and resource spawning

## Technical Approach
- expanded `WORLD_GEN` config and added `chunkMetadata`
- updated `MainScene.create` to honor world size, use new spawn, and follow player
- replaced hard-coded width/height in `resourceSystem` with `WORLD_GEN.world`

## Performance
- no additional per-frame allocations; camera follow uses existing sprite

## Risks & Rollback
- large world bounds may expose unseen areas if camera logic changes
- revert commit 70a21d7 to restore previous bounds

## QA Steps
- log `WORLD_GEN.world.width` in console -> 10000
- check `chunkMetadata.size` -> 0


------
https://chatgpt.com/codex/tasks/task_e_68ae71b2c29c8322895954a38e6c0199