### PR TITLE
feat: track chunk state registry

### DIFF
--- a/systems/world_gen/chunks/chunkManager.js
+++ b/systems/world_gen/chunks/chunkManager.js
@@ -1,0 +1,25 @@
+// systems/world_gen/chunks/chunkManager.js
+// Minimal chunk manager that updates chunkRegistry on load/unload/metadata change.
+
+import { setChunkState } from './chunkRegistry.js';
+import { chunkMetadata } from '../worldGenConfig.js';
+
+const ChunkManager = {
+    loadChunk(cx, cy) {
+        setChunkState(cx, cy, 'loaded');
+    },
+
+    unloadChunk(cx, cy) {
+        const key = `${cx},${cy}`;
+        const meta = chunkMetadata.get(key);
+        setChunkState(cx, cy, meta && meta.dirty ? 'dirty' : 'unloaded');
+    },
+
+    markMetadataDirty(cx, cy, data) {
+        const key = `${cx},${cy}`;
+        chunkMetadata.set(key, { ...(chunkMetadata.get(key) || {}), ...data, dirty: true });
+        setChunkState(cx, cy, 'dirty');
+    },
+};
+
+export default ChunkManager;

--- a/systems/world_gen/chunks/chunkRegistry.js
+++ b/systems/world_gen/chunks/chunkRegistry.js
@@ -1,0 +1,22 @@
+// systems/world_gen/chunks/chunkRegistry.js
+// Tracks load states for procedural world chunks.
+
+export const chunkRegistry = new Map();
+
+function _key(cx, cy) {
+    return `${cx},${cy}`;
+}
+
+export function getChunkState(cx, cy) {
+    return chunkRegistry.get(_key(cx, cy))?.state;
+}
+
+export function setChunkState(cx, cy, state) {
+    const key = _key(cx, cy);
+    const entry = chunkRegistry.get(key);
+    if (entry) {
+        entry.state = state;
+    } else {
+        chunkRegistry.set(key, { state });
+    }
+}


### PR DESCRIPTION
## Summary
- add chunk registry map for chunk load/unload states
- hook minimal ChunkManager helpers to update registry

## Technical Approach
- add `chunkRegistry.js` providing `getChunkState` and `setChunkState`
- add `chunkManager.js` to set registry state on load, unload, or metadata change

## Performance
- simple Map lookups and updates; no per-frame allocations

## Risks & Rollback
- new chunk tracking is isolated; revert by removing `systems/world_gen/chunks`

## QA Steps
- load a few chunks
- in console, call `getChunkState(10,10)` and see `"loaded"`
- unload the chunk; if metadata changed, state becomes `"dirty"`, otherwise `"unloaded"`

------
https://chatgpt.com/codex/tasks/task_e_68ae7a9cad088322a3f79f6d117858d1