### PR TITLE
fix(resource): clamp spawn area

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -10,8 +10,10 @@ export default function createResourceSystem(scene) {
         const all = WORLD_GEN?.spawns?.resources;
         if (!all) return;
 
-        for (const [key, cfg] of Object.entries(all))
-            _spawnResourceGroup(key, cfg);
+        for (const [key, cfg] of Object.entries(all)) {
+            const count = _spawnResourceGroup(key, cfg);
+            console.log(`resources: ${key}=${count}`);
+        }
 
         if (!scene._resourcesCollider) {
             scene._resourcesCollider = scene.physics.add.collider(
@@ -75,10 +77,14 @@ export default function createResourceSystem(scene) {
 
         const w = WORLD_GEN.world.width;
         const h = WORLD_GEN.world.height;
-        const minX = 0,
-            maxX = w,
-            minY = 0,
-            maxY = h;
+        const centerX = WORLD_GEN.spawn?.x ?? w * 0.5;
+        const centerY = WORLD_GEN.spawn?.y ?? h * 0.5;
+        const halfArea = 750;
+        // TODO: remove spawn-area clamp once chunk-based spawning is in place
+        const minX = Math.max(0, centerX - halfArea),
+            maxX = Math.min(w, centerX + halfArea),
+            minY = Math.max(0, centerY - halfArea),
+            maxY = Math.min(h, centerY + halfArea);
 
         const tooClose = (x, y, w, h) => {
             const children = scene.resources.getChildren();
@@ -475,6 +481,7 @@ export default function createResourceSystem(scene) {
             spawned += spawnCluster();
             attempts++;
         }
+        return spawned;
     }
 
     // ----- Dev Helpers -----

--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -40,7 +40,7 @@ export const WORLD_GEN = {
     resources: {
         // Weighted rock variants A–E (A most common → E rarest)
         rocks: {
-          maxActive: 13,
+          maxActive: 20,
           minSpacing: 100,  // pixels between rock centers
           clusterMin: 3,
           clusterMax: 6,
@@ -64,7 +64,7 @@ export const WORLD_GEN = {
         },
         // Weighted tree variants
         trees: {
-          maxActive: 13,
+          maxActive: 30,
           minSpacing: 100,
           clusterMin: 3,
           clusterMax: 6,
@@ -132,10 +132,11 @@ export const WORLD_GEN = {
       },
     },
   },
+  spawn: { x: 5000, y: 5000 },
 };
 
-// Center spawn point
-export const spawn = { x: 5000, y: 5000 };
+// Center spawn point (re-export for convenience)
+export const spawn = WORLD_GEN.spawn;
 
 // Session-scoped metadata for procedural chunks
 export const chunkMetadata = new Map();


### PR DESCRIPTION
### Summary
- restrict resource spawning to a 1500x1500 box centered on the world spawn point
- temporarily increase rock and tree counts for easier testing

### Technical Approach
- clamp resource positions in `systems/resourceSystem.js`
- expose `WORLD_GEN.spawn` and bump `maxActive` values in `systems/world_gen/worldGenConfig.js`

### Performance
- all calculations occur during world generation; no per-frame allocations or loops

### Risks & Rollback
- clamped area and elevated counts are temporary; revert commit `895cc1e` to roll back

### QA Steps
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7fb42d7c8322b73a7a25b36ed53f