### PR TITLE
feat(world-gen): add resource registry

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -3,14 +3,18 @@
 import { WORLD_GEN } from './world_gen/worldGenConfig.js';
 import { DESIGN_RULES } from '../data/designRules.js';
 import { RESOURCE_DB } from '../data/resourceDatabase.js';
+import { getResourceRegistry } from './world_gen/resources/registry.js';
+import './world_gen/resources/rocks.js';
+import './world_gen/resources/trees.js';
+import './world_gen/resources/bushes.js';
 
 export default function createResourceSystem(scene) {
     // ----- Public API -----
     function spawnAllResources() {
-        const all = WORLD_GEN?.spawns?.resources;
-        if (!all) return;
-
-        for (const [key, cfg] of Object.entries(all)) {
+        const registry = getResourceRegistry();
+        for (const [key, gen] of registry.entries()) {
+            const cfg = gen();
+            if (!cfg) continue;
             const count = _spawnResourceGroup(key, cfg);
             console.log(`resources: ${key}=${count}`);
         }

--- a/systems/world_gen/resources/bushes.js
+++ b/systems/world_gen/resources/bushes.js
@@ -1,0 +1,4 @@
+import { WORLD_GEN } from '../worldGenConfig.js';
+import { registerResourceType } from './registry.js';
+
+registerResourceType('bushes', () => WORLD_GEN?.spawns?.resources?.bushes);

--- a/systems/world_gen/resources/registry.js
+++ b/systems/world_gen/resources/registry.js
@@ -1,0 +1,14 @@
+const registry = new Map();
+
+export function registerResourceType(id, generatorFn) {
+    if (typeof id !== 'string' || typeof generatorFn !== 'function') {
+        throw new Error('Invalid resource registration');
+    }
+    registry.set(id, generatorFn);
+}
+
+export function getResourceRegistry() {
+    return registry;
+}
+
+export default { registerResourceType, getResourceRegistry };

--- a/systems/world_gen/resources/rocks.js
+++ b/systems/world_gen/resources/rocks.js
@@ -1,0 +1,4 @@
+import { WORLD_GEN } from '../worldGenConfig.js';
+import { registerResourceType } from './registry.js';
+
+registerResourceType('rocks', () => WORLD_GEN?.spawns?.resources?.rocks);

--- a/systems/world_gen/resources/trees.js
+++ b/systems/world_gen/resources/trees.js
@@ -1,0 +1,4 @@
+import { WORLD_GEN } from '../worldGenConfig.js';
+import { registerResourceType } from './registry.js';
+
+registerResourceType('trees', () => WORLD_GEN?.spawns?.resources?.trees);

--- a/test/systems/resourceRegistry.test.js
+++ b/test/systems/resourceRegistry.test.js
@@ -1,0 +1,45 @@
+// test/systems/resourceRegistry.test.js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import createResourceSystem from '../../systems/resourceSystem.js';
+import {
+    getResourceRegistry,
+    registerResourceType,
+} from '../../systems/world_gen/resources/registry.js';
+
+const noop = () => {};
+
+const scene = {
+    resources: { getChildren: () => [] },
+    physics: { add: { collider: noop, overlap: noop } },
+    player: {},
+    zombies: { getChildren: () => [] },
+    time: { delayedCall: noop },
+    events: { on: noop, once: noop, off: noop },
+    textures: { get: () => ({ getSourceImage: () => ({ width: 0, height: 0 }) }) },
+    add: { image: () => ({ setDepth: noop, setScale: noop }) },
+    uiScene: { inventory: { addItem: noop } },
+};
+
+const system = createResourceSystem(scene);
+
+test('existing resource modules register themselves', () => {
+    const registry = getResourceRegistry();
+    assert.ok(registry.has('rocks'));
+    assert.ok(registry.has('trees'));
+    assert.ok(registry.has('bushes'));
+});
+
+test('resourceSystem iterates over registry entries', () => {
+    const registry = getResourceRegistry();
+    for (const key of registry.keys()) {
+        registry.set(key, () => ({ variants: [] }));
+    }
+    let called = false;
+    registerResourceType('dummy', () => {
+        called = true;
+        return { variants: [] };
+    });
+    system.spawnAllResources();
+    assert.equal(called, true);
+});


### PR DESCRIPTION
## Summary
- add a central registry for world gen resources
- allow rocks, trees, and bushes to self-register
- iterate registry in resourceSystem and verify via tests

## Technical Approach
- added systems/world_gen/resources/registry.js to collect generator functions
- rocks.js, trees.js, bushes.js modules register their configs
- resourceSystem.js now imports registry entries and iterates them
- added tests to ensure registration and iteration

## Performance
- registry uses static maps and avoids per-frame allocations
- no changes to update loops

## Risks & Rollback
- missing registrations would prevent resource spawning
- rollback by reverting commit

## QA Steps
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae88f03d808322a9756cedd7422d05