### PR TITLE
feat: add per-chunk resource spawning

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -148,6 +148,27 @@ export default class MainScene extends Phaser.Scene {
         this.player._speedMult = 1;
         this.player._inBush = false;
 
+        // Groups
+        this.zombies = this.physics.add.group();
+        this.bullets = this.physics.add.group({
+            classType: Phaser.Physics.Arcade.Image,
+            maxSize: 32,
+        });
+        this.meleeHits = this.physics.add.group();
+        this.resources = this.physics.add.group();
+        this.droppedItems = this.add.group();
+        this._dropCleanupEvent = this.time.addEvent({
+            delay: 1000,
+            loop: true,
+            callback: () => this._cleanupDroppedItems(),
+        });
+        this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+            this._dropCleanupEvent?.remove(false);
+        });
+        this.events.once(Phaser.Scenes.Events.DESTROY, () => {
+            this._dropCleanupEvent?.remove(false);
+        });
+
         this.chunkManager = new ChunkManager(this, 1);
         this.chunkManager.update(this.player.x, this.player.y);
 
@@ -219,27 +240,6 @@ export default class MainScene extends Phaser.Scene {
             this.events.once(Phaser.Scenes.Events.SHUTDOWN, _teardown);
             this.events.once(Phaser.Scenes.Events.DESTROY, _teardown);
         }
-
-        // Groups
-        this.zombies = this.physics.add.group();
-        this.bullets = this.physics.add.group({
-            classType: Phaser.Physics.Arcade.Image,
-            maxSize: 32,
-        });
-        this.meleeHits = this.physics.add.group();
-        this.resources = this.physics.add.group();
-        this.droppedItems = this.add.group();
-        this._dropCleanupEvent = this.time.addEvent({
-            delay: 1000,
-            loop: true,
-            callback: () => this._cleanupDroppedItems(),
-        });
-        this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
-            this._dropCleanupEvent?.remove(false);
-        });
-        this.events.once(Phaser.Scenes.Events.DESTROY, () => {
-            this._dropCleanupEvent?.remove(false);
-        });
 
         // Spawn resources from WORLD_GEN (all resource groups)
         this.spawnAllResources();


### PR DESCRIPTION
Summary:
- spawn chunk resources on `chunk:load` with persisted harvest state
- ensure resource group exists before chunk load to prevent undefined errors
- remove temporary spawn-area clamp from resource spawning

Technical Approach:
- systems/resourceSystem.js: added `spawnChunkResources` and event wiring
- scenes/MainScene.js: moved resource group creation ahead of chunk manager init
- systems/resourceSystem.js: expanded `_spawnResourceGroup` with bounds and callbacks

Performance:
- resource nodes spawn only on chunk load; no per-frame allocations introduced

Risks & Rollback:
- spawning counts may drift if chunk metadata becomes inconsistent
- rollback by reverting commit 371004c

QA Steps:
- `npm test`
- in game: enter a new chunk and confirm 35-45 resources spawn
- harvest some nodes, leave and return to the chunk: harvested nodes remain gone
- start a new game to confirm no resource-spawn errors

------
https://chatgpt.com/codex/tasks/task_e_68ae8ba9486c8322965e681056dd5475