### PR TITLE
feat: persist chunk metadata across chunk unload/load

### DIFF
--- a/systems/world_gen/chunks/ChunkManager.js
+++ b/systems/world_gen/chunks/ChunkManager.js
@@ -3,6 +3,7 @@
 
 import Chunk from './Chunk.js';
 import { WORLD_GEN } from '../worldGenConfig.js';
+import { saveChunk, loadChunk } from './chunkStore.js';
 
 export default class ChunkManager {
     constructor(scene, radius = 1) {
@@ -38,7 +39,8 @@ export default class ChunkManager {
                 const ny = (cy + dy + rows) % rows;
                 const key = this._key(nx, ny);
                 if (!this.loadedChunks.has(key)) {
-                    const chunk = new Chunk(nx, ny);
+                    const saved = loadChunk(key);
+                    const chunk = new Chunk(nx, ny, saved?.meta);
                     chunk.load(this.scene);
                     this.loadedChunks.set(key, chunk);
                     this.scene.events.emit('chunk:load', chunk);
@@ -52,6 +54,7 @@ export default class ChunkManager {
             const distX = Math.min(dx, cols - dx);
             const distY = Math.min(dy, rows - dy);
             if (distX > radius || distY > radius) {
+                saveChunk(key, chunk.serialize());
                 chunk.unload();
                 this.loadedChunks.delete(key);
                 this.scene.events.emit('chunk:unload', chunk);

--- a/systems/world_gen/chunks/chunkStore.js
+++ b/systems/world_gen/chunks/chunkStore.js
@@ -1,0 +1,18 @@
+const store = new Map();
+
+export function saveChunk(id, data) {
+    store.set(id, data);
+}
+
+export function loadChunk(id) {
+    return store.get(id);
+}
+
+export function deleteChunk(id) {
+    store.delete(id);
+}
+
+export function clearChunkStore() {
+    store.clear();
+}
+


### PR DESCRIPTION
Summary:
- add in-memory chunk store to retain chunk metadata when chunks unload
- integrate chunk manager to save chunk state on unload and restore when reloaded

Technical Approach:
- systems/world_gen/chunks/chunkStore.js
- systems/world_gen/chunks/ChunkManager.js

Performance:
- simple Map-based storage; no per-frame allocations introduced

Risks & Rollback:
- affects chunk serialization; revert commit to disable persistence if issues arise

QA Steps:
- harvest a resource in a chunk
- walk far enough to unload the chunk (watch console for `chunk:unload`)
- return to the same coordinates; harvested node remains gone
- refresh the page; chunks reset since store is session-only


------
https://chatgpt.com/codex/tasks/task_e_68ae8ee8b0788322a0299c397f355278