### PR TITLE
feat: persist chunk metadata across chunk unload/load

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -8,6 +8,7 @@ import createDayNightSystem from '../systems/world_gen/dayNightSystem.js';
 import createResourceSystem from '../systems/resourceSystem.js';
 import createInputSystem from '../systems/inputSystem.js';
 import ChunkManager from '../systems/world_gen/chunks/ChunkManager.js';
+import { clearChunkStore } from '../systems/world_gen/chunks/chunkStore.js';
 
 export default class MainScene extends Phaser.Scene {
     constructor() {
@@ -122,6 +123,10 @@ export default class MainScene extends Phaser.Scene {
         this._sprintDrainPerSec = 2; // -2 / sec
         this._isSprinting = false;
 
+        // Reset any previous chunk metadata and UI state
+        clearChunkStore();
+        // Ensure fresh UI on respawn
+        this.scene.stop('UIScene');
         // Launch UI and keep a reference
         this.scene.launch('UIScene', {
             playerData: { health: this.health, stamina: this.stamina, ammo: 0 },

--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -1004,7 +1004,8 @@ export default class UIScene extends Phaser.Scene {
     // Day/Night HUD update (called by MainScene)
     // -------------------------
     updateTimeDisplay(dayIndex, phaseLabel, progress) {
-        if (!this.dayNightLabel || !this.timeBarFill) return;
+        // skip if elements were destroyed (e.g., during scene restart)
+        if (!this.dayNightLabel?.active || !this.timeBarFill?.active || !this.timeBarBg?.active) return;
         this.dayNightLabel.setText(`Day ${dayIndex} — ${phaseLabel}`);
         const barW = this.timeBarBg.width;
         const clamped = Phaser.Math.Clamp(progress, 0, 1);

--- a/systems/world_gen/chunks/ChunkManager.js
+++ b/systems/world_gen/chunks/ChunkManager.js
@@ -3,6 +3,7 @@
 
 import Chunk from './Chunk.js';
 import { WORLD_GEN } from '../worldGenConfig.js';
+import { saveChunk, loadChunk } from './chunkStore.js';
 
 export default class ChunkManager {
     constructor(scene, radius = 1) {
@@ -38,7 +39,8 @@ export default class ChunkManager {
                 const ny = (cy + dy + rows) % rows;
                 const key = this._key(nx, ny);
                 if (!this.loadedChunks.has(key)) {
-                    const chunk = new Chunk(nx, ny);
+                    const saved = loadChunk(key);
+                    const chunk = new Chunk(nx, ny, saved?.meta);
                     chunk.load(this.scene);
                     this.loadedChunks.set(key, chunk);
                     this.scene.events.emit('chunk:load', chunk);
@@ -52,6 +54,7 @@ export default class ChunkManager {
             const distX = Math.min(dx, cols - dx);
             const distY = Math.min(dy, rows - dy);
             if (distX > radius || distY > radius) {
+                saveChunk(key, chunk.serialize());
                 chunk.unload();
                 this.loadedChunks.delete(key);
                 this.scene.events.emit('chunk:unload', chunk);

--- a/systems/world_gen/chunks/chunkStore.js
+++ b/systems/world_gen/chunks/chunkStore.js
@@ -1,0 +1,18 @@
+const store = new Map();
+
+export function saveChunk(id, data) {
+    store.set(id, data);
+}
+
+export function loadChunk(id) {
+    return store.get(id);
+}
+
+export function deleteChunk(id) {
+    store.delete(id);
+}
+
+export function clearChunkStore() {
+    store.clear();
+}
+


### PR DESCRIPTION
Summary:
- add in-memory chunk store to retain chunk metadata when chunks unload
- integrate chunk manager to save chunk state on unload and restore when reloaded
- reset chunk store and restart UIScene on new game to avoid respawn crash

Technical Approach:
- systems/world_gen/chunks/chunkStore.js
- systems/world_gen/chunks/ChunkManager.js
- scenes/MainScene.create: clearChunkStore and restart UIScene
- scenes/UIScene.updateTimeDisplay: guard destroyed elements

Performance:
- simple Map-based storage; no per-frame allocations; respawn guard runs only at scene init

Risks & Rollback:
- affects chunk serialization and scene restart logic; revert commits to disable if issues arise

QA Steps:
- harvest a resource in a chunk
- walk far enough to unload the chunk (watch console for `chunk:unload`)
- return to same coordinates; harvested node remains gone
- die and respawn; game loads without UI crash
- refresh the page; chunks reset since store is session-only


------
https://chatgpt.com/codex/tasks/task_e_68ae8ee8b0788322a0299c397f355278