### PR TITLE
feat: add chunk and performance overlays

### DIFF
--- a/scenes/DevUIScene.js
+++ b/scenes/DevUIScene.js
@@ -33,6 +33,8 @@ export default class DevUIScene extends Phaser.Scene {
         this._rows = [];
         this._scroll = 0;
         this._editing = null;  // currently focused editor API
+        this._scrollbarTrack = null;
+        this._scrollbarThumb = null;
 
         // Build zombie index (names for display; keys used to spawn)
         this._zIndex = this._buildZombieIndex();
@@ -157,6 +159,8 @@ export default class DevUIScene extends Phaser.Scene {
         }, y);
         y = this._rowToggle('No Cooldown',     () => DevTools.cheats.noCooldown,   v => DevTools.cheats.noCooldown = v, y);
         y = this._rowToggle('Infinite Ammo',   () => DevTools.cheats.noAmmo,       v => DevTools.cheats.noAmmo = v, y);
+        y = this._rowToggle('Chunk Details',   () => DevTools.cheats.chunkDetails, v => DevTools.setChunkDetails(v, main), y);
+        y = this._rowToggle('Performance HUD', () => DevTools.cheats.performanceHud, v => DevTools.setPerformanceHud(v, main), y);
 
         y = this._sectionTitle('Spawners', y);
         y = this._enemySpawnerRow(y);
@@ -164,6 +168,9 @@ export default class DevUIScene extends Phaser.Scene {
 
         y = this._sectionTitle('Control', y);
         y = this._gameSpeedRow(y);
+
+        this._createScrollbar();
+        this._scrollBy(0);
 
         // Keyboard handling
         this.input.keyboard.on('keydown', (ev) => this._onKey(ev));
@@ -179,8 +186,10 @@ export default class DevUIScene extends Phaser.Scene {
             if (!consumed) this._scrollBy(dy); // otherwise scroll the whole panel
         });
 
-        // Make sure hitbox render and game speed react immediately
-        DevTools.applyHitboxCheat(this.scene.get('MainScene'));
+        // Make sure overlays and game speed react immediately
+        DevTools.applyHitboxCheat(main);
+        DevTools.setChunkDetails(DevTools.cheats.chunkDetails, main);
+        DevTools.setPerformanceHud(DevTools.cheats.performanceHud, main);
         DevTools.applyTimeScale(this);
     }
 
@@ -1197,6 +1206,48 @@ export default class DevUIScene extends Phaser.Scene {
         const maxScroll = Math.max(0, totalH - viewH);
         this._scroll = Phaser.Math.Clamp(this._scroll + delta * 0.3, 0, maxScroll);
         this.content.y = 54 - this._scroll;
+        this._updateScrollbar();
+    }
+
+    _createScrollbar() {
+        const viewH = this.scale.height - 54 - 24;
+        const trackX = this.scale.width - 6;
+        const trackY = 54;
+        const trackW = 4;
+        const trackH = viewH;
+        this._scrollbarTrack = this.add.rectangle(trackX, trackY, trackW, trackH, 0xffffff, 0.2)
+            .setOrigin(0, 0).setDepth(2);
+        this._scrollbarThumb = this.add.rectangle(trackX, trackY, trackW, 20, 0xffffff, 0.6)
+            .setOrigin(0, 0).setDepth(3).setInteractive();
+        this.input.setDraggable(this._scrollbarThumb);
+        this._scrollbarThumb.on('drag', (pointer, dragX, dragY) => {
+            const maxY = trackY + trackH - this._scrollbarThumb.height;
+            const newY = Phaser.Math.Clamp(dragY, trackY, maxY);
+            this._scrollbarThumb.y = newY;
+            const totalH = this._estimateContentHeight();
+            const maxScroll = Math.max(0, totalH - viewH);
+            const ratio = (newY - trackY) / (trackH - this._scrollbarThumb.height);
+            this._scroll = ratio * maxScroll;
+            this.content.y = 54 - this._scroll;
+        });
+        this._updateScrollbar();
+    }
+
+    _updateScrollbar() {
+        if (!this._scrollbarTrack || !this._scrollbarThumb) return;
+        const viewH = this.scale.height - 54 - 24;
+        const totalH = this._estimateContentHeight();
+        const trackH = viewH;
+        const trackY = 54;
+        const visible = totalH > viewH;
+        this._scrollbarTrack.setVisible(visible);
+        this._scrollbarThumb.setVisible(visible);
+        if (!visible) return;
+        const thumbH = Math.max(20, trackH * (viewH / totalH));
+        this._scrollbarThumb.height = thumbH;
+        const maxScroll = Math.max(0, totalH - viewH);
+        const ratio = (maxScroll === 0) ? 0 : this._scroll / maxScroll;
+        this._scrollbarThumb.y = trackY + (trackH - thumbH) * ratio;
     }
 
     _estimateContentHeight() {

--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -5,6 +5,7 @@
 // - Melee cones draw as time-synced thin slices. Batch size (1 or 2) is configurable.
 
 import { ITEM_DB } from '../data/itemDatabase.js';
+import { WORLD_GEN } from './world_gen/worldGenConfig.js';
 
 const DevTools = {
     // ─────────────────────────────────────────────────────────────
@@ -17,6 +18,10 @@ const DevTools = {
         noAmmo:       false,
         noStamina:    false,
         noCooldown:   false,
+
+        // Debug overlays
+        chunkDetails:    false,
+        performanceHud:  false,
 
         // NEW: how many slices to draw per fast tick (1 or 2)
         meleeSliceBatch: 1,
@@ -39,6 +44,15 @@ const DevTools = {
     _lastFastDraw: 0,
     _lastSlowDraw: 0,
     _lastScene: null,
+
+    // Chunk grid & performance HUD
+    _chunkGfx: null,
+    _chunkText: null,
+    _chunkTimer: null,
+    _chunkScene: null,
+    _perfText: null,
+    _perfTimer: null,
+    _perfScene: null,
 
     // Public helpers used by scenes
     isPlayerInvisible() { return !!this.cheats.invisible; },
@@ -78,10 +92,14 @@ const DevTools = {
         this.cheats.noAmmo         = false;
         this.cheats.noStamina      = false;
         this.cheats.noCooldown     = false;
+        this.cheats.chunkDetails   = false;
+        this.cheats.performanceHud = false;
         this.cheats.meleeSliceBatch = 1;
         this.cheats.timeScale       = 1;
         this._enemySpawnPrefs = null;
         this._itemSpawnPrefs  = null;
+        this._stopChunkDetails();
+        this._stopPerformanceHud();
         // Re-apply hitbox visibility immediately (hides layers if they were on)
         try { this.applyHitboxCheat(scene || this._lastScene); } catch {}
         // Reset global game speed
@@ -190,6 +208,26 @@ const DevTools = {
         if (this._lastScene) this.applyHitboxCheat(this._lastScene);
     },
 
+    setChunkDetails(value, scene) {
+        this.cheats.chunkDetails = !!value;
+        if (value) this._startChunkDetails(scene);
+        else this._stopChunkDetails();
+    },
+
+    setPerformanceHud(value, scene) {
+        this.cheats.performanceHud = !!value;
+        if (value) this._startPerformanceHud(scene);
+        else this._stopPerformanceHud();
+    },
+
+    _overlayBaseY(scene) {
+        const ui = scene?.uiScene;
+        if (ui && ui.staminaBarY != null && ui.staminaBarHeight != null) {
+            return ui.staminaBarY + ui.staminaBarHeight + 4;
+        }
+        return 60; // fallback below top HUD
+    },
+
     applyHitboxCheat(scene) {
         this._ensureLayers(scene);
         const vis = !!this.cheats.showHitboxes;
@@ -224,6 +262,116 @@ const DevTools = {
             this._drawSlow(scene);
             this._lastSlowDraw = now;
         }
+    },
+
+    // ─────────────────────────────────────────────────────────────
+    // Chunk details overlay
+    // ─────────────────────────────────────────────────────────────
+    _startChunkDetails(scene) {
+        if (!scene) return;
+        if (this._chunkScene && this._chunkScene !== scene) this._stopChunkDetails();
+        this._chunkScene = scene;
+        if (!this._chunkGfx) {
+            this._chunkGfx = scene.add.graphics().setDepth(998);
+        }
+        const baseY = this._overlayBaseY(scene);
+        if (!this._chunkText) {
+            this._chunkText = scene.add.text(4, baseY, '', { fontSize: '12px', color: '#0f0' })
+                .setScrollFactor(0)
+                .setDepth(999);
+        } else {
+            this._chunkText.setY(baseY);
+        }
+        if (this._perfText) {
+            this._perfText.setY(baseY + 14);
+        }
+        if (!this._chunkTimer) {
+            this._chunkTimer = scene.time.addEvent({ delay: 100, loop: true, callback: () => { this._drawChunkDetails(scene); } });
+        }
+    },
+
+    _stopChunkDetails() {
+        const scene = this._chunkScene || this._perfScene;
+        if (this._chunkTimer) { try { this._chunkTimer.remove(); } catch {} }
+        if (this._chunkGfx) { try { this._chunkGfx.destroy(); } catch {} }
+        if (this._chunkText) { try { this._chunkText.destroy(); } catch {} }
+        this._chunkTimer = null;
+        this._chunkGfx = null;
+        this._chunkText = null;
+        this._chunkScene = null;
+        if (this._perfText && scene) {
+            this._perfText.setY(this._overlayBaseY(scene));
+        }
+    },
+
+    _drawChunkDetails(scene) {
+        const g = this._chunkGfx;
+        if (!g || !scene) return;
+        const cm = scene.chunkManager;
+        const size = WORLD_GEN.chunk.size;
+        const cam = scene.cameras?.main;
+        const view = cam?.worldView;
+        if (!view) return;
+        g.clear().lineStyle(1, 0x00ffff, 1);
+        const startX = Math.floor(view.x / size);
+        const endX = Math.floor(view.right / size);
+        const startY = Math.floor(view.y / size);
+        const endY = Math.floor(view.bottom / size);
+        for (let cx = startX; cx <= endX; cx++) {
+            for (let cy = startY; cy <= endY; cy++) {
+                const x = cx * size;
+                const y = cy * size;
+                const key = `${cx},${cy}`;
+                if (cm?.loadedChunks?.has(key)) {
+                    g.fillStyle(0x00ff00, 0.15).fillRect(x, y, size, size);
+                }
+                g.strokeRect(x, y, size, size);
+            }
+        }
+        const player = scene.player;
+        const pcx = Math.floor((player?.x || 0) / size);
+        const pcy = Math.floor((player?.y || 0) / size);
+        const loaded = cm?.loadedChunks?.size || 0;
+        if (this._chunkText) {
+            this._chunkText.setText(`Chunk (${pcx},${pcy}) loaded: ${loaded}`);
+        }
+    },
+
+    // ─────────────────────────────────────────────────────────────
+    // Performance HUD
+    // ─────────────────────────────────────────────────────────────
+    _startPerformanceHud(scene) {
+        if (!scene) return;
+        if (this._perfScene && this._perfScene !== scene) this._stopPerformanceHud();
+        this._perfScene = scene;
+        const baseY = this._overlayBaseY(scene);
+        const perfY = this._chunkText ? baseY + 14 : baseY;
+        if (!this._perfText) {
+            this._perfText = scene.add.text(4, perfY, '', { fontSize: '12px', color: '#0f0' })
+                .setScrollFactor(0)
+                .setDepth(999);
+        } else {
+            this._perfText.setY(perfY);
+        }
+        if (!this._perfTimer) {
+            this._perfTimer = scene.time.addEvent({ delay: 500, loop: true, callback: () => { this._drawPerformanceHud(scene); } });
+        }
+    },
+
+    _stopPerformanceHud() {
+        if (this._perfTimer) { try { this._perfTimer.remove(); } catch {} }
+        if (this._perfText) { try { this._perfText.destroy(); } catch {} }
+        this._perfTimer = null;
+        this._perfText = null;
+        this._perfScene = null;
+    },
+
+    _drawPerformanceHud(scene) {
+        if (!this._perfText || !scene) return;
+        const fps = Math.round(scene.game?.loop?.actualFps || 0);
+        const heap = performance?.memory?.usedJSHeapSize ? Math.round(performance.memory.usedJSHeapSize / 1048576) : 0;
+        const timers = scene.time?.events?.size || 0;
+        this._perfText.setText(`FPS: ${fps}\nHeap: ${heap}MB\nTimers: ${timers}`);
     },
 
     // ─────────────────────────────────────────────────────────────

--- a/test/systems/DevTools.test.js
+++ b/test/systems/DevTools.test.js
@@ -2,9 +2,80 @@ import test from 'node:test';
 import assert from 'node:assert';
 import DevTools from '../../systems/DevTools.js';
 
+function makeStubScene() {
+    const events = new Set();
+    const time = {
+        addEvent(opts) {
+            const evt = {
+                delay: opts.delay,
+                callback: opts.callback,
+                removed: false,
+                remove() { this.removed = true; events.delete(this); },
+            };
+            events.add(evt);
+            return evt;
+        },
+        events,
+    };
+    const add = {
+        graphics() {
+            return {
+                destroyed: false,
+                clear() { return this; },
+                lineStyle() { return this; },
+                strokeRect() { return this; },
+                fillStyle() { return this; },
+                fillRect() { return this; },
+                setDepth() { return this; },
+                setScrollFactor() { return this; },
+                destroy() { this.destroyed = true; },
+            };
+        },
+        text(x, y, msg, style) {
+            return {
+                x, y, text: msg, style,
+                destroyed: false,
+                setText(t) { this.text = t; return this; },
+                setScrollFactor() { return this; },
+                setDepth() { return this; },
+                destroy() { this.destroyed = true; },
+            };
+        },
+    };
+    const cameras = { main: { worldView: { x: 0, y: 0, width: 1000, height: 1000, right: 1000, bottom: 1000 } } };
+    const player = { x: 250, y: 250 };
+    const chunkManager = { loadedChunks: new Map([['0,0', {}]]), cols: 20, rows: 20 };
+    const game = { loop: { actualFps: 60 } };
+    return { time, add, cameras, player, chunkManager, game };
+}
+
 test('setMeleeSliceBatch clamps to 1 or 2', () => {
     DevTools.setMeleeSliceBatch(2);
     assert.equal(DevTools.cheats.meleeSliceBatch, 2);
     DevTools.setMeleeSliceBatch(0);
     assert.equal(DevTools.cheats.meleeSliceBatch, 1);
+});
+
+test('chunkDetails toggle manages overlay and timer', () => {
+    const scene = makeStubScene();
+    DevTools.setChunkDetails(true, scene);
+    assert.ok(DevTools._chunkGfx);
+    assert.ok(DevTools._chunkTimer);
+    DevTools._chunkTimer.callback();
+    assert.match(DevTools._chunkText.text, /loaded/);
+    DevTools.setChunkDetails(false);
+    assert.equal(DevTools._chunkGfx, null);
+    assert.equal(DevTools._chunkTimer, null);
+});
+
+test('performanceHud toggle manages HUD and timer', () => {
+    const scene = makeStubScene();
+    DevTools.setPerformanceHud(true, scene);
+    assert.ok(DevTools._perfText);
+    assert.ok(DevTools._perfTimer);
+    DevTools._perfTimer.callback();
+    assert.match(DevTools._perfText.text, /FPS/);
+    DevTools.setPerformanceHud(false);
+    assert.equal(DevTools._perfText, null);
+    assert.equal(DevTools._perfTimer, null);
 });


### PR DESCRIPTION
## Summary
- add DevTools cheats to visualize chunks and runtime performance
- timers throttle overlay refresh to avoid per-frame allocations
- expose chunk details and performance HUD toggles in Dev UI
- move chunk and performance text below stamina bar
- make Dev Tools menu scrollable with a draggable scrollbar

## Technical Approach
- augment `DevTools` with `chunkDetails` and `performanceHud` toggles
- draw chunk grid and performance HUD via timed Phaser events
- position overlay text using `UIScene` stamina bar offsets
- add scrollbar elements in `DevUIScene` tied into scroll calculations
- wire new cheats into `DevUIScene` for in-game toggling
- unit tests cover enabling/disabling overlays

## Performance
- overlay updates run on throttled timers (100ms/500ms) with reusable graphics/text
- timers and graphics destroyed on toggle off to free resources
- scrollbar updates reuse existing math and avoid per-frame allocations

## Risks & Rollback
- overlay logic depends on scene structures; unexpected scene shapes may break display
- scrollbar drag uses input events; mis-sized content may misbehave
- revert via `git revert cd4e8b2` and `git revert 0b65de8`

## QA Steps
- Open Dev Tools menu and confirm "Chunk Details" and "Performance HUD" toggles appear
- Enable `chunkDetails`; grid highlights loaded chunks and counter updates below stamina bar
- Enable `performanceHud`; FPS, heap usage, and timer count refresh below stamina bar
- Scroll Dev Tools menu using mouse wheel or scrollbar to reach bottom
- Disable both toggles; overlays and timers should disappear

------
https://chatgpt.com/codex/tasks/task_e_68ae95124c68832296d480e6e718c239