### PR TITLE
feat: stream world chunks with session persistence

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -7,6 +7,7 @@ import createCombatSystem from '../systems/combatSystem.js';
 import createDayNightSystem from '../systems/dayNightSystem.js';
 import createResourceSystem from '../systems/resourceSystem.js';
 import createInputSystem from '../systems/inputSystem.js';
+import createWorldGenSystem from '../systems/world_gen/worldGenSystem.js';
 
 export default class MainScene extends Phaser.Scene {
     constructor() {
@@ -129,6 +130,7 @@ export default class MainScene extends Phaser.Scene {
         this.combat = createCombatSystem(this);
         this.dayNight = createDayNightSystem(this);
         this.resourceSystem = createResourceSystem(this);
+        this.worldGen = createWorldGenSystem(this);
         this.inputSystem = createInputSystem(this);
 
         // Player

--- a/systems/world_gen/chunks/chunkStore.js
+++ b/systems/world_gen/chunks/chunkStore.js
@@ -1,0 +1,34 @@
+// systems/world_gen/chunks/chunkStore.js
+// Session-scoped chunk persistence.
+
+const memoryStore = {};
+
+export function saveChunk(id, data) {
+    if (id == null) return;
+    memoryStore[id] = data;
+    try {
+        if (typeof window !== 'undefined' && window.sessionStorage) {
+            window.sessionStorage.setItem('chunk:' + id, JSON.stringify(data));
+        }
+    } catch (err) {
+        // ignore storage errors (e.g., quota, SSR)
+    }
+}
+
+export function loadChunk(id) {
+    if (id == null) return null;
+    if (id in memoryStore) return memoryStore[id];
+    try {
+        if (typeof window !== 'undefined' && window.sessionStorage) {
+            const raw = window.sessionStorage.getItem('chunk:' + id);
+            if (raw) {
+                const data = JSON.parse(raw);
+                memoryStore[id] = data;
+                return data;
+            }
+        }
+    } catch (err) {
+        // ignore parse/storage errors
+    }
+    return null;
+}

--- a/systems/world_gen/worldGenSystem.js
+++ b/systems/world_gen/worldGenSystem.js
@@ -1,0 +1,88 @@
+// systems/world_gen/worldGenSystem.js
+// Basic chunk-based world streaming.
+import { saveChunk, loadChunk } from './chunks/chunkStore.js';
+
+export default function createWorldGenSystem(scene) {
+    const CHUNK_SIZE = 256;
+    const PRELOAD_RADIUS = 32;
+
+    const activeChunks = new Map();
+    let currentId = null;
+    let playerChunkX = 0;
+    let playerChunkY = 0;
+
+    function createChunk(id) {
+        return {
+            id,
+            meta: null,
+            serialize() {
+                return { meta: this.meta };
+            },
+            deserialize(data) {
+                this.meta = data?.meta || null;
+            },
+        };
+    }
+
+    function ensureChunk(id) {
+        if (activeChunks.has(id)) return;
+        const chunk = createChunk(id);
+        const saved = loadChunk(id);
+        if (saved) {
+            chunk.deserialize(saved);
+        } else {
+            setTimeout(() => {
+                chunk.meta = { generated: true };
+            }, 0);
+        }
+        activeChunks.set(id, chunk);
+    }
+
+    function unloadChunk(id) {
+        const chunk = activeChunks.get(id);
+        if (!chunk) return;
+        saveChunk(id, chunk.serialize());
+        activeChunks.delete(id);
+    }
+
+    function swapChunk(id) {
+        if (currentId === id) return;
+        if (currentId) unloadChunk(currentId);
+        ensureChunk(id);
+        currentId = id;
+    }
+
+    function preload(x, y) {
+        const id = x + ',' + y;
+        if (activeChunks.has(id)) return;
+        setTimeout(() => ensureChunk(id), 0);
+    }
+
+    function tick() {
+        const p = scene.player;
+        if (!p) return;
+        const cx = (p.x / CHUNK_SIZE) | 0;
+        const cy = (p.y / CHUNK_SIZE) | 0;
+        if (cx !== playerChunkX || cy !== playerChunkY) {
+            const id = cx + ',' + cy;
+            swapChunk(id);
+            playerChunkX = cx;
+            playerChunkY = cy;
+        }
+
+        const localX = p.x - playerChunkX * CHUNK_SIZE;
+        const localY = p.y - playerChunkY * CHUNK_SIZE;
+        if (localX < PRELOAD_RADIUS) preload(playerChunkX - 1, playerChunkY);
+        if (localX > CHUNK_SIZE - PRELOAD_RADIUS) preload(playerChunkX + 1, playerChunkY);
+        if (localY < PRELOAD_RADIUS) preload(playerChunkX, playerChunkY - 1);
+        if (localY > CHUNK_SIZE - PRELOAD_RADIUS) preload(playerChunkX, playerChunkY + 1);
+    }
+
+    scene.events.on('update', tick);
+    scene.events.once('shutdown', () => {
+        scene.events.off('update', tick);
+        activeChunks.forEach((_, id) => unloadChunk(id));
+    });
+
+    return { tick };
+}


### PR DESCRIPTION
## Summary
- stream player world chunks and preload neighbors asynchronously
- persist chunk metadata for the session

## Technical Approach
- add `systems/world_gen/chunks/chunkStore.js` for `saveChunk`/`loadChunk`
- add `systems/world_gen/worldGenSystem.js` to manage chunk swapping
- hook `createWorldGenSystem` into `scenes/MainScene` lifecycle

## Performance
- reuses chunk coords to avoid per-frame object churn
- asynchronous `setTimeout` prevents blocking the game loop

## Risks & Rollback
- basic stub chunk data; unexpected state loss can be reverted by removing `world_gen` system

## QA Steps
- launch game; move near chunk edges to trigger background generation
- verify player movement remains smooth during chunk transitions
- reload scene to ensure chunk metadata persists within session

------
https://chatgpt.com/codex/tasks/task_e_68af7d7ece248322816742374eaf9de0