### PR TITLE
fix: throttle chunk detail overlay

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -40,6 +40,12 @@ const DevTools = {
     _lastSlowDraw: 0,
     _lastScene: null,
 
+    // Chunk detail overlay state
+    _chunkTimer: null,
+    _chunkGfx: null,
+    _chunkScene: null,
+    _chunkShutdown: null,
+
     // Public helpers used by scenes
     isPlayerInvisible() { return !!this.cheats.invisible; },
     shouldConsumeAmmo() { return !this.cheats.noAmmo; },
@@ -224,6 +230,53 @@ const DevTools = {
             this._drawSlow(scene);
             this._lastSlowDraw = now;
         }
+    },
+
+    // Toggle chunk detail overlay (draws player chunk boundary)
+    setChunkDetails(value, scene) {
+        if (value) {
+            if (scene) this._chunkScene = scene;
+            if (this._chunkScene) this._startChunkDetails(this._chunkScene);
+        } else {
+            this._stopChunkDetails();
+        }
+    },
+
+    _startChunkDetails(scene) {
+        if (this._chunkTimer || !scene?.time || !scene.add) return;
+        this._chunkScene = scene;
+        this._chunkGfx = scene.add.graphics().setDepth(998).setVisible(true);
+        const draw = () => {
+            try {
+                const g = this._chunkGfx;
+                const p = this._chunkScene?.player;
+                if (!g || !p) return;
+                const size = 256;
+                const cx = Math.floor(p.x / size) * size;
+                const cy = Math.floor(p.y / size) * size;
+                g.clear().lineStyle(1, 0x00ff00, 1).strokeRect(cx, cy, size, size);
+            } catch {}
+        };
+        draw();
+        this._chunkTimer = scene.time.addEvent({ delay: 200, loop: true, callback: draw });
+        this._chunkShutdown = () => this._stopChunkDetails();
+        scene.events?.once?.('shutdown', this._chunkShutdown);
+    },
+
+    _stopChunkDetails() {
+        if (this._chunkTimer) {
+            try { this._chunkTimer.remove(); } catch {}
+            this._chunkTimer = null;
+        }
+        if (this._chunkScene?.events && this._chunkShutdown) {
+            try { this._chunkScene.events.off('shutdown', this._chunkShutdown); } catch {}
+        }
+        if (this._chunkGfx) {
+            try { this._chunkGfx.destroy(); } catch {}
+            this._chunkGfx = null;
+        }
+        this._chunkScene = null;
+        this._chunkShutdown = null;
     },
 
     // ─────────────────────────────────────────────────────────────

--- a/test/systems/DevTools.test.js
+++ b/test/systems/DevTools.test.js
@@ -8,3 +8,32 @@ test('setMeleeSliceBatch clamps to 1 or 2', () => {
     DevTools.setMeleeSliceBatch(0);
     assert.equal(DevTools.cheats.meleeSliceBatch, 1);
 });
+
+test('chunk detail overlay registers and cleans up', () => {
+    let removed = false;
+    let destroyed = false;
+    let offCalled = false;
+    let shutdownCb = null;
+    const fakeTimer = { remove: () => { removed = true; } };
+    const fakeGfx = {
+        clear() { return this; }, lineStyle() { return this; }, strokeRect() {},
+        setDepth() { return this; }, setVisible() { return this; }, destroy() { destroyed = true; return this; }
+    };
+    const fakeScene = {
+        player: { x: 0, y: 0 },
+        time: { addEvent: () => fakeTimer },
+        add: { graphics: () => fakeGfx },
+        events: {
+            once(ev, cb) { if (ev === 'shutdown') shutdownCb = cb; },
+            off(ev, cb) { if (ev === 'shutdown' && cb === shutdownCb) offCalled = true; }
+        }
+    };
+
+    DevTools.setChunkDetails(true, fakeScene);
+    assert.ok(DevTools._chunkTimer);
+    DevTools.setChunkDetails(false);
+    assert.equal(DevTools._chunkTimer, null);
+    assert.ok(removed);
+    assert.ok(destroyed);
+    assert.ok(offCalled);
+});


### PR DESCRIPTION
Summary:
- add optional chunk boundary debug overlay and clean up timers/events

Technical Approach:
- systems/DevTools.js adds setChunkDetails plus throttled draw logic
- test/systems/DevTools.test.js covers timer removal and event cleanup

Performance:
- overlay draws every 200ms using a single Graphics instance to avoid per-frame allocations

Risks & Rollback:
- assumes fixed 256px chunk size; revert commit if overlay misbehaves

QA Steps:
- npm test
- toggle DevTools.setChunkDetails(true/false) while moving between chunks and confirm no freeze


------
https://chatgpt.com/codex/tasks/task_e_68af82e906608322a21cb2f7806143ac