### PR TITLE
fix: handle devtools-triggered resize

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -64,6 +64,6 @@ function applyPixelPerfectZoom() {
     game.scale.setZoom(zoom);
 }
 
-// Run once and on resize
-window.addEventListener('resize', applyPixelPerfectZoom);
+// Run once and whenever Phaser adjusts the canvas size
+game.scale.on('resize', applyPixelPerfectZoom);
 applyPixelPerfectZoom();


### PR DESCRIPTION
### Summary
- wire pixel-perfect zoom to Phaser's scale resize event to avoid render crashes when the browser window resizes (e.g. opening DevTools)

### Technical Approach
- bootstrap.js `applyPixelPerfectZoom` now runs on `game.scale` resize events

### Performance
- zoom recalculation only runs on scale resize events; no per-frame allocations

### Risks & Rollback
- minimal: if resize behavior regresses, revert `bootstrap.js` changes

### QA Steps
- Launch game
- Open DevTools and close repeatedly; verify no `renderWebGL` errors


------
https://chatgpt.com/codex/tasks/task_e_68af8416b8788322ab47bccd42a0bc98