### PR TITLE
fix(resource): keep resourceSystem wrapper open

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -463,12 +463,11 @@ function createResourceSystem(scene) {
                         }
                         if (typeof b.setImmovable === 'function') b.setImmovable(true);
                     }
-                }
                 // Important for static bodies: refresh after size/offset/scale/origin/crop changes
                 if (b.moves === false && typeof trunk.refreshBody === 'function') {
                     try { trunk.refreshBody(); } catch {}
                 }
-            }
+                }
 
             const leavesCfg = def.world?.leaves;
             if (leavesCfg) {


### PR DESCRIPTION
Summary
- fix illegal top-level return by keeping createResourceSystem scope open

Technical Approach
- adjust systems/resourceSystem.js to nest the static body refresh within the physics block and ensure the module return executes inside createResourceSystem

Performance
- no impact; change only affects initialization code outside critical loops

Risks & Rollback
- incorrect brace placement could reintroduce syntax errors; revert via `git revert 695bc9007aa56d23e870c87a29fe241d813dafc9`

QA Steps
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afcb50f5e08322a7bfbc5ba3c31c19