### PR TITLE
fix(camera): round follow to stop resource jitter

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -157,7 +157,8 @@ export default class MainScene extends Phaser.Scene {
             .setDepth(900)
             .setCollideWorldBounds(false);
 
-        this.cameras.main.startFollow(this.player);
+        this.cameras.main.startFollow(this.player, true);
+        this.cameras.main.setRoundPixels(true);
 
         this.player._speedMult = 1;
         this.player._inBush = false;


### PR DESCRIPTION
## Summary
- round camera follow to whole pixels to prevent resource jitter

## Technical Approach
- scenes/MainScene.js: startFollow with `roundPixels` and enable `setRoundPixels`

## Performance
- uses built-in camera rounding; no per-frame allocations

## Risks & Rollback
- low risk: revert commit `0a1e3c3` if jitter returns or follow breaks

## QA Steps
- `npm test`
- run the game, move in all directions, ensure resources no longer jitter


------
https://chatgpt.com/codex/tasks/task_e_68afe305dd50832282be8fe6c9edc8e5