### PR TITLE
fix: night overlay covers resources and hitboxes render on top

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -364,7 +364,8 @@ export default class MainScene extends Phaser.Scene {
             .rectangle(0, 0, w, h, 0x000000)
             .setOrigin(0, 0)
             .setScrollFactor(0)
-            .setDepth(999)
+            // Render above all world sprites so night affects trees/rocks
+            .setDepth(10000)
             .setAlpha(0);
 
         // --- DevTools integration ---

--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -425,11 +425,11 @@ const DevTools = {
             if (this._gfx[k]) { this._gfx[k].destroy(); this._gfx[k] = null; }
         }
 
-        // Create pooled graphics (drawn above gameplay, below UI)
-        this._gfx.resources = scene.add.graphics().setDepth(994).setVisible(false);
-        this._gfx.enemies   = scene.add.graphics().setDepth(995).setVisible(false);
-        this._gfx.attacks   = scene.add.graphics().setDepth(996).setVisible(false);
-        this._gfx.player    = scene.add.graphics().setDepth(997).setVisible(false);
+        // Create pooled graphics above night overlay and world sprites
+        this._gfx.resources = scene.add.graphics().setDepth(10001).setVisible(false);
+        this._gfx.enemies   = scene.add.graphics().setDepth(10002).setVisible(false);
+        this._gfx.attacks   = scene.add.graphics().setDepth(10003).setVisible(false);
+        this._gfx.player    = scene.add.graphics().setDepth(10004).setVisible(false);
 
         this._lastScene = scene;
     },


### PR DESCRIPTION
## Summary
- ensure night overlay darkens trees and rocks
- keep debug hitbox graphics above resources

## Technical Approach
- raise night overlay depth in `scenes/MainScene.js`
- bump DevTools debug graphic depths in `systems/DevTools.js`

## Performance
- static depth values; no per-frame allocations

## Risks & Rollback
- high depth values could overlap unexpected UI layers
- revert commit if rendering order issues appear

## QA Steps
- Start the game and wait for night
- Toggle hitbox debug view
- Confirm trees and rocks are darkened and hitboxes draw above them


------
https://chatgpt.com/codex/tasks/task_e_68afeb909bc88322bfb0f9ad15de55d9