### PR TITLE
fix: night overlay covers resources and hitboxes render on top

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -364,7 +364,8 @@ export default class MainScene extends Phaser.Scene {
             .rectangle(0, 0, w, h, 0x000000)
             .setOrigin(0, 0)
             .setScrollFactor(0)
-            .setDepth(999)
+            // Render above all world sprites so night affects trees/rocks
+            .setDepth(10000)
             .setAlpha(0);
 
         // --- DevTools integration ---

--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -425,11 +425,11 @@ const DevTools = {
             if (this._gfx[k]) { this._gfx[k].destroy(); this._gfx[k] = null; }
         }
 
-        // Create pooled graphics (drawn above gameplay, below UI)
-        this._gfx.resources = scene.add.graphics().setDepth(994).setVisible(false);
-        this._gfx.enemies   = scene.add.graphics().setDepth(995).setVisible(false);
-        this._gfx.attacks   = scene.add.graphics().setDepth(996).setVisible(false);
-        this._gfx.player    = scene.add.graphics().setDepth(997).setVisible(false);
+        // Create pooled graphics above night overlay and world sprites
+        this._gfx.resources = scene.add.graphics().setDepth(10001).setVisible(false);
+        this._gfx.enemies   = scene.add.graphics().setDepth(10002).setVisible(false);
+        this._gfx.attacks   = scene.add.graphics().setDepth(10003).setVisible(false);
+        this._gfx.player    = scene.add.graphics().setDepth(10004).setVisible(false);
 
         this._lastScene = scene;
     },

--- a/systems/combatSystem.js
+++ b/systems/combatSystem.js
@@ -111,7 +111,7 @@ export default function createCombatSystem(scene) {
                 .rectangle(0, 0, cam.width, cam.height, 0x000000, 0.5)
                 .setOrigin(0, 0)
                 .setScrollFactor(0)
-                .setDepth(999);
+                .setDepth(20000);
             const cx = cam.worldView.x + cam.worldView.width * 0.5;
             const cy = cam.worldView.y + cam.worldView.height * 0.5;
             scene.gameOverText = scene.add
@@ -121,7 +121,7 @@ export default function createCombatSystem(scene) {
                     color: '#ffffff',
                 })
                 .setOrigin(0.5)
-                .setDepth(1000);
+                .setDepth(20001);
             scene.gameOverText.setStroke('#720c0c', 4);
             scene.respawnPrompt = scene.add
                 .text(cx, cy + 20, 'Press SPACE to Respawn', {
@@ -130,7 +130,7 @@ export default function createCombatSystem(scene) {
                     color: '#ffffff',
                 })
                 .setOrigin(0.5)
-                .setDepth(1000);
+                .setDepth(20001);
             return;
         }
         try {

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -360,6 +360,7 @@ function createResourceSystem(scene) {
                     .setScale(scale)
                     .setDepth((scene.player?.depth ?? 900) + 2 + depthOff)
                     .setCrop(0, 0, frameW, topH);
+                scene.resourcesDecor && scene.resourcesDecor.add(top);
                 trunk.setCrop(0, topH, frameW, frameH - topH);
                 trunk.setData('topSprite', top);
                 trunk.once('destroy', () => top.destroy());
@@ -519,6 +520,7 @@ function createResourceSystem(scene) {
                     .setScale(scale)
                     .setDepth((def.leavesDepth ?? def.depth ?? 5) + depthOff)
                     .setCrop(cropX, cropY, lw, lh);
+                scene.resourcesDecor && scene.resourcesDecor.add(leaves);
 
                 const dispW = trunk.displayWidth;
                 const dispH = trunk.displayHeight;


### PR DESCRIPTION
## Summary
- ensure rock tops and tree leaves are included when drawing resource hitboxes
- keep death screen overlay above world sprites

## Technical Approach
- add rock-top and tree-leaf sprites to `resourcesDecor` so debug graphics cover full resource
- raise game-over overlay and text depths beyond resource layers

## Performance
- depth constants and group additions only; no per-frame allocations

## Risks & Rollback
- extreme depth values could overlap unexpected UI
- revert commit if any layering regressions occur

## QA Steps
- Start the game and wait for night
- Toggle hitbox debug view
- Confirm trees and rocks are fully darkened and hitboxes draw above them
- Die and ensure game-over overlay and text render above all resources

------
https://chatgpt.com/codex/tasks/task_e_68afeb909bc88322bfb0f9ad15de55d9