### PR TITLE
feat: noise-based resource density for world gen

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
         "start": "node bootstrap.js",
         "test": "node --test"
     },
+    "dependencies": {
+        "simplex-noise": "^4.0.1"
+    },
     "keywords": [],
     "author": "",
     "license": "ISC"

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -7,6 +7,7 @@ import { getResourceRegistry } from './world_gen/resources/registry.js';
 import './world_gen/resources/rocks.js';
 import './world_gen/resources/trees.js';
 import './world_gen/resources/bushes.js';
+import { getDensity } from './world_gen/resources/density.js';
 
 function createResourceSystem(scene) {
     // Background job timers for time-sliced chunk population
@@ -123,7 +124,7 @@ function createResourceSystem(scene) {
 
         if (resources.length === 0) {
             // Lower per-chunk density: target 25–35 total resources
-            const total = Phaser.Math.Between(25, 35);
+            const total = getDensity(chunk.cx, chunk.cy, WORLD_GEN?.seed ?? 0);
             const keys = Array.from(registry.keys());
             const counts = {};
             let remaining = total;

--- a/systems/world_gen/resources/density.js
+++ b/systems/world_gen/resources/density.js
@@ -1,0 +1,37 @@
+import { createNoise2D } from 'simplex-noise';
+
+const _noiseCache = new Map();
+
+function _noise(seed) {
+    let n = _noiseCache.get(seed);
+    if (!n) {
+        const rnd = _mulberry32(_hash(seed));
+        n = createNoise2D(rnd);
+        _noiseCache.set(seed, n);
+    }
+    return n;
+}
+
+function _hash(x) {
+    x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+    x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+    x ^= x >>> 16;
+    return x >>> 0;
+}
+
+function _mulberry32(a) {
+    return function () {
+        let t = (a += 0x6d2b79f5);
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+export function getDensity(cx, cy, seed = 0) {
+    const noise = _noise(seed);
+    const base = (noise(cx * 0.1, cy * 0.1) + 1) / 2; // 0..1
+    const rng = _mulberry32(_hash(seed + cx + cy));
+    const total = Math.round(25 + base * 8 + rng() * 2);
+    return total;
+}

--- a/test/systems/world_gen/density.test.js
+++ b/test/systems/world_gen/density.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getDensity } from '../../../systems/world_gen/resources/density.js';
+
+test('getDensity returns consistent values for same seed', () => {
+    const seed = 12345;
+    const a = getDensity(10, 10, seed);
+    const b = getDensity(10, 10, seed);
+    assert.strictEqual(a, b);
+});
+
+test('changing seed shifts patterns', () => {
+    const coords = [
+        [10, 10],
+        [15, 20],
+        [20, 25],
+    ];
+    const seedA = 1;
+    const seedB = 2;
+    const same = coords.every(([x, y]) => getDensity(x, y, seedA) === getDensity(x, y, seedB));
+    assert.ok(!same);
+});


### PR DESCRIPTION
Summary
- Add deterministic `getDensity` utility using simplex noise and hashed RNG.
- Resource system uses `getDensity` to calculate per-chunk resource totals.
- Include tests ensuring density stability and seed-based variation.

Technical Approach
- Added `systems/world_gen/resources/density.js` implementing noise + mulberry RNG.
- Updated `systems/resourceSystem.js` to call `getDensity` instead of random total.
- Added `simplex-noise` dependency.
- Added `test/systems/world_gen/density.test.js`.

Performance
- Density calculations run once per chunk spawn; no per-frame allocations.

Risks & Rollback
- Resource distribution may change; revert commits to restore previous random totals.

QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b39f6cd08322851c5b6cbff7f986