### PR TITLE
feat: show biome names in chunk overlay

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -5,7 +5,14 @@
 // - Melee cones draw as time-synced thin slices. Batch size (1 or 2) is configurable.
 
 import { ITEM_DB } from '../data/itemDatabase.js';
-import { WORLD_GEN } from './world_gen/worldGenConfig.js';
+import { WORLD_GEN, BIOME_IDS } from './world_gen/worldGenConfig.js';
+import { getBiome } from './world_gen/biomes/biomeMap.js';
+
+const BIOME_NAMES = {
+    [BIOME_IDS.PLAINS]: 'Plains',
+    [BIOME_IDS.FOREST]: 'Forest',
+    [BIOME_IDS.DESERT]: 'Desert',
+};
 
 const DevTools = {
     // ─────────────────────────────────────────────────────────────
@@ -412,8 +419,10 @@ const DevTools = {
         const pcx = Math.floor((player?.x || 0) / size);
         const pcy = Math.floor((player?.y || 0) / size);
         const loaded = cm?.loadedChunks?.size || 0;
+        const biomeId = getBiome(pcx, pcy);
+        const name = BIOME_NAMES[biomeId] || 'Unknown';
         if (this._chunkText) {
-            this._chunkText.setText(`Chunk (${pcx},${pcy}) loaded: ${loaded}`);
+            this._chunkText.setText(`Chunk (${pcx},${pcy}) loaded: ${loaded} Biome: ${name}`);
         }
         // Lightly mark the player's current chunk
         const px = pcx * size;

--- a/test/systems/DevTools.test.js
+++ b/test/systems/DevTools.test.js
@@ -1,6 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import DevTools from '../../systems/DevTools.js';
+import { WORLD_GEN, BIOME_IDS } from '../../systems/world_gen/worldGenConfig.js';
+import { getBiome } from '../../systems/world_gen/biomes/biomeMap.js';
+
+const BIOME_NAMES = {
+    [BIOME_IDS.PLAINS]: 'Plains',
+    [BIOME_IDS.FOREST]: 'Forest',
+    [BIOME_IDS.DESERT]: 'Desert',
+};
 
 function makeStubScene() {
     const events = new Set();
@@ -48,8 +56,10 @@ function makeStubScene() {
         },
     };
     const cameras = { main: { worldView: { x: 0, y: 0, width: 1000, height: 1000, right: 1000, bottom: 1000 } } };
-    const player = { x: 250, y: 250 };
-    const chunkManager = { loadedChunks: new Map([['0,0', {}]]), cols: 20, rows: 20 };
+    const player = { x: WORLD_GEN.spawn.x, y: WORLD_GEN.spawn.y };
+    const cx = Math.floor(WORLD_GEN.spawn.x / WORLD_GEN.chunk.size);
+    const cy = Math.floor(WORLD_GEN.spawn.y / WORLD_GEN.chunk.size);
+    const chunkManager = { loadedChunks: new Map([[`${cx},${cy}`, {}]]), cols: 20, rows: 20 };
     const game = { loop: { actualFps: 60 } };
     return { time, add, cameras, player, chunkManager, game, gfxStyles: styles };
 }
@@ -69,7 +79,11 @@ test('chunkDetails toggle manages overlay and timer', () => {
     assert.match(DevTools._chunkText.text, /loaded/);
     assert.ok(scene.gfxStyles.some(s => s.width === 4 && s.color === 0x0000aa));
     DevTools._chunkTimer.callback();
-    assert.match(DevTools._chunkText.text, /loaded/);
+    const spawnCx = Math.floor(WORLD_GEN.spawn.x / WORLD_GEN.chunk.size);
+    const spawnCy = Math.floor(WORLD_GEN.spawn.y / WORLD_GEN.chunk.size);
+    const biomeId = getBiome(spawnCx, spawnCy);
+    const expected = BIOME_NAMES[biomeId];
+    assert.match(DevTools._chunkText.text, new RegExp(`Biome: ${expected}`));
     DevTools.setChunkDetails(false);
     assert.equal(DevTools._chunkGfx, null);
     assert.equal(DevTools._chunkTimer, null);


### PR DESCRIPTION
## Summary
- display biome names on DevTools chunk overlay
- cover biome label in DevTools chunk details unit test

## Technical Approach
- map `BIOME_IDS` to names and call `getBiome` in `_drawChunkDetails`
- test expected biome label for spawn chunk

## Performance
- no additional per-frame allocations; overlay updates every 250ms

## Risks & Rollback
- low risk: overlay text lookup could mislabel if ids change
- rollback: revert commit `feat(devtools): show biome name in chunk details`

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4be80c8408322b24192e0e1620c4b