### PR TITLE
feat: Poisson-based resource spawning

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -6,6 +6,7 @@ import { RESOURCE_DB } from '../data/resourceDatabase.js';
 import { getResourceRegistry } from './world_gen/resources/registry.js';
 import { getBiome } from './world_gen/biomes/biomeMap.js';
 import { getDensity } from './world_gen/noise.js';
+import * as poissonSampler from './world_gen/resources/poissonSampler.js';
 import './world_gen/resources/rocks.js';
 import './world_gen/resources/trees.js';
 import './world_gen/resources/bushes.js';
@@ -133,64 +134,52 @@ function createResourceSystem(scene) {
         const resources = meta.resources;
 
         if (resources.length === 0) {
-            // Lower per-chunk density: target 25–35 total resources
-            const total = Phaser.Math.Between(25, 35);
+            const totalTarget = Phaser.Math.Between(35, 45);
+            const centers = poissonSampler.generate(bounds, 100);
+            Phaser.Utils.Array.Shuffle(centers);
             const keys = Array.from(registry.keys());
-            const counts = {};
-            let remaining = total;
-            for (let i = 0; i < keys.length; i++) {
-                const left = keys.length - i - 1;
-                // Per-group bounds tuned to match 25–35 total across 3 groups
-                const min = 8;
-                const max = 12;
-                const maxAllowed = Math.min(max, remaining - min * left);
-                const minAllowed = Math.max(min, remaining - max * left);
-                const c =
-                    i === keys.length - 1
-                        ? remaining
-                        : Phaser.Math.Between(minAllowed, maxAllowed);
-                counts[keys[i]] = c;
-                remaining -= c;
-            }
-
-            // Time-sliced population: spawn small batches over several ticks
-            const tasks = keys
-                .map((k) => {
-                    const gen = registry.get(k);
-                    const cfg = gen && gen();
-                    return cfg ? { key: k, cfg, remaining: counts[k] | 0 } : null;
-                })
-                .filter(Boolean);
-
-            // Cancel any prior job for this chunk and start a new one
-            _cancelChunkJob(chunk);
-            const perBatch = 4; // aim to create up to ~4 resources per step
-            const keyStr = _keyForChunk(chunk);
-            const step = () => {
-                // Stop if chunk got unloaded
-                if (!chunk.group || chunk.group.active === false) {
-                    _cancelChunkJob(chunk);
-                    return;
-                }
-                let producedThisStep = 0;
-                for (let i = 0; i < tasks.length; i++) {
-                    const t = tasks[i];
-                    if (!t || t.remaining <= 0) continue;
-                    const want = Math.min(perBatch, t.remaining);
-                const spawned = _spawnResourceGroup(t.key, t.cfg, {
-                    bounds,
-                    count: want,
-                    noRespawn: true,
-                    proximityGroup: chunk.group,
-                    onCreate(trunk, id, x, y) {
-                        chunk.group.add(trunk);
-                        const idx = resources.push({
-                            type: t.key,
-                            id,
-                                x,
-                                y,
-                                harvested: false,
-                            }) - 1;
+            let total = 0;
+            for (let i = 0; i < centers.length && total < totalTarget; i++) {
+                const c = centers[i];
+                const key = Phaser.Utils.Array.GetRandom(keys);
+                const gen = registry.get(key);
+                const cfg = gen && gen();
+                if (!cfg) continue;
+                const clusterChance = cfg.clusterChance ?? 0.5;
+                const clusterRadius = cfg.clusterRadius ?? cfg.minSpacing ?? 50;
+                const clusterMin = cfg.clusterMin ?? 1;
+                const clusterMax = cfg.clusterMax ?? 1;
+                const clusterCount =
+                    Math.random() < clusterChance
+                        ? Phaser.Math.Between(clusterMin, clusterMax)
+                        : 1;
+                const cfgOverride = {
+                    ...cfg,
+                    clusterMin: clusterCount,
+                    clusterMax: clusterCount,
+                    clusterRadius,
+                };
+                const spawned =
+                    _spawnResourceGroup(key, cfgOverride, {
+                        bounds: {
+                            minX: Math.round(c.x),
+                            maxX: Math.round(c.x),
+                            minY: Math.round(c.y),
+                            maxY: Math.round(c.y),
+                        },
+                        count: clusterCount,
+                        noRespawn: true,
+                        proximityGroup: chunk.group,
+                        onCreate(trunk, id, x, y) {
+                            chunk.group.add(trunk);
+                            const idx =
+                                resources.push({
+                                    type: key,
+                                    id,
+                                    x,
+                                    y,
+                                    harvested: false,
+                                }) - 1;
                             trunk.setData('chunkIdx', idx);
                             trunk.setData('chunk', chunk);
                         },
@@ -199,23 +188,8 @@ function createResourceSystem(scene) {
                             if (idx != null) resources[idx].harvested = true;
                         },
                     }) | 0;
-                    t.remaining = Math.max(0, t.remaining - spawned);
-                    producedThisStep += spawned;
-                    // Light cap per step to keep frame time stable
-                    if (producedThisStep >= perBatch) break;
-                }
-
-                // If all tasks finished, stop; else schedule next slice
-                const done = tasks.every((t) => !t || t.remaining <= 0);
-                if (done) {
-                    _cancelChunkJob(chunk);
-                } else {
-                    const ev = scene.time.addEvent({ delay: 60, callback: step });
-                    _chunkJobs.set(keyStr, ev);
-                }
-            };
-            const ev = scene.time.addEvent({ delay: 20, callback: step });
-            _chunkJobs.set(keyStr, ev);
+                total += spawned;
+            }
         } else {
             for (let i = 0; i < resources.length; i++) {
                 const r = resources[i];

--- a/systems/world_gen/resources/poissonSampler.js
+++ b/systems/world_gen/resources/poissonSampler.js
@@ -1,0 +1,82 @@
+// systems/world_gen/resources/poissonSampler.js
+// Simple Poisson-disc sampler for evenly spaced points.
+// bounds: {minX, maxX, minY, maxY}
+// radius: minimum distance between points
+
+export function generate(bounds, radius, rng = Math.random) {
+    const cellSize = radius / Math.SQRT2;
+    const width = bounds.maxX - bounds.minX;
+    const height = bounds.maxY - bounds.minY;
+    const gridW = Math.ceil(width / cellSize);
+    const gridH = Math.ceil(height / cellSize);
+    const grid = new Array(gridW * gridH).fill(null);
+    const samples = [];
+    const active = [];
+    const k = 30; // attempts per active point
+
+    const toGrid = (x, y) => {
+        const gx = Math.floor((x - bounds.minX) / cellSize);
+        const gy = Math.floor((y - bounds.minY) / cellSize);
+        return { gx, gy };
+    };
+
+    const inBounds = (x, y) =>
+        x >= bounds.minX && x <= bounds.maxX && y >= bounds.minY && y <= bounds.maxY;
+
+    const isFar = (x, y) => {
+        const { gx, gy } = toGrid(x, y);
+        const minX = Math.max(gx - 2, 0);
+        const maxX = Math.min(gx + 2, gridW - 1);
+        const minY = Math.max(gy - 2, 0);
+        const maxY = Math.min(gy + 2, gridH - 1);
+        for (let yy = minY; yy <= maxY; yy++) {
+            for (let xx = minX; xx <= maxX; xx++) {
+                const s = grid[yy * gridW + xx];
+                if (!s) continue;
+                const dx = s.x - x;
+                const dy = s.y - y;
+                if (dx * dx + dy * dy < radius * radius) return false;
+            }
+        }
+        return true;
+    };
+
+    const addPoint = (x, y) => {
+        const { gx, gy } = toGrid(x, y);
+        grid[gy * gridW + gx] = { x, y };
+        const p = { x, y };
+        samples.push(p);
+        active.push(p);
+    };
+
+    const randBetween = (min, max) => rng() * (max - min) + min;
+
+    // initial point
+    addPoint(randBetween(bounds.minX, bounds.maxX), randBetween(bounds.minY, bounds.maxY));
+
+    while (active.length > 0) {
+        const idx = (rng() * active.length) | 0;
+        const p = active[idx];
+        let found = false;
+        for (let i = 0; i < k; i++) {
+            const ang = randBetween(0, Math.PI * 2);
+            const dist = randBetween(radius, radius * 2);
+            const x = p.x + Math.cos(ang) * dist;
+            const y = p.y + Math.sin(ang) * dist;
+            if (inBounds(x, y) && isFar(x, y)) {
+                addPoint(x, y);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            active[idx] = active[active.length - 1];
+            active.pop();
+        }
+    }
+
+    return samples;
+}
+
+export default { generate };
+


### PR DESCRIPTION
## Summary
- add Poisson-disc sampler for evenly spaced points
- spawn chunk resources using sampler with cluster handling and 35–45 node cap

## Technical Approach
- new `systems/world_gen/resources/poissonSampler.js` implements Poisson-disc generation
- `systems/resourceSystem.js` uses sampler in `spawnChunkResources` to place resource clusters or single nodes

## Performance
- generation happens once per chunk load, avoiding per-frame allocations

## Risks & Rollback
- resource density may need tuning; rollback by reverting the commit

## QA Steps
- `npm test`
- load a chunk and confirm 35–45 resources spawn


------
https://chatgpt.com/codex/tasks/task_e_68b4d5c0ebc48322b7f3625a6afe118b