### PR TITLE
fix: persist chunk details toggle across DevTools openings

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -271,53 +271,6 @@ const DevTools = {
         }
     },
 
-    // Toggle chunk detail overlay (draws player chunk boundary)
-    setChunkDetails(value, scene) {
-        if (value) {
-            if (scene) this._chunkScene = scene;
-            if (this._chunkScene) this._startChunkDetails(this._chunkScene);
-        } else {
-            this._stopChunkDetails();
-        }
-    },
-
-    _startChunkDetails(scene) {
-        if (this._chunkTimer || !scene?.time || !scene.add) return;
-        this._chunkScene = scene;
-        this._chunkGfx = scene.add.graphics().setDepth(998).setVisible(true);
-        const draw = () => {
-            try {
-                const g = this._chunkGfx;
-                const p = this._chunkScene?.player;
-                if (!g || !p) return;
-                const size = 256;
-                const cx = Math.floor(p.x / size) * size;
-                const cy = Math.floor(p.y / size) * size;
-                g.clear().lineStyle(1, 0x00ff00, 1).strokeRect(cx, cy, size, size);
-            } catch {}
-        };
-        draw();
-        this._chunkTimer = scene.time.addEvent({ delay: 200, loop: true, callback: draw });
-        this._chunkShutdown = () => this._stopChunkDetails();
-        scene.events?.once?.('shutdown', this._chunkShutdown);
-    },
-
-    _stopChunkDetails() {
-        if (this._chunkTimer) {
-            try { this._chunkTimer.remove(); } catch {}
-            this._chunkTimer = null;
-        }
-        if (this._chunkScene?.events && this._chunkShutdown) {
-            try { this._chunkScene.events.off('shutdown', this._chunkShutdown); } catch {}
-        }
-        if (this._chunkGfx) {
-            try { this._chunkGfx.destroy(); } catch {}
-            this._chunkGfx = null;
-        }
-        this._chunkScene = null;
-        this._chunkShutdown = null;
-    },
-
     // ─────────────────────────────────────────────────────────────
     // Chunk details overlay
     // ─────────────────────────────────────────────────────────────

--- a/test/systems/DevTools.test.js
+++ b/test/systems/DevTools.test.js
@@ -49,6 +49,7 @@ function makeStubScene() {
                 x, y, text: msg, style,
                 destroyed: false,
                 setText(t) { this.text = t; return this; },
+                setY(y) { this.y = y; return this; },
                 setScrollFactor() { return this; },
                 setDepth() { return this; },
                 destroy() { this.destroyed = true; },
@@ -78,6 +79,10 @@ test('chunkDetails toggle manages overlay and timer', () => {
     assert.ok(DevTools._chunkTimer);
     assert.match(DevTools._chunkText.text, /loaded/);
     assert.ok(scene.gfxStyles.some(s => s.width === 4 && s.color === 0x0000aa));
+    // Simulate reopening Dev UI which re-applies current toggle
+    assert.equal(DevTools.cheats.chunkDetails, true);
+    DevTools.setChunkDetails(DevTools.cheats.chunkDetails, scene);
+    assert.ok(DevTools._chunkGfx);
     DevTools._chunkTimer.callback();
     const spawnCx = Math.floor(WORLD_GEN.spawn.x / WORLD_GEN.chunk.size);
     const spawnCy = Math.floor(WORLD_GEN.spawn.y / WORLD_GEN.chunk.size);


### PR DESCRIPTION
## Summary
- keep chunk details overlay state when reopening Dev Tools
- remove legacy chunk overlay helpers
- add regression test for chunk detail persistence

## Technical Approach
- `systems/DevTools.js` now updates the cheat flag in `setChunkDetails` and relies on a single overlay implementation
- extended unit tests to simulate Dev UI reopen and verify state preservation

## Performance
- no additional per-frame allocations; removed unused overlay code

## Risks & Rollback
- low risk: only touches Dev Tools debug overlay
- rollback by reverting commit `fix(devtools): persist chunk details toggle`

## QA Steps
- `npm test`
- run the game, enable Chunk Details, open/close Dev Tools, verify overlay state persists until reset


------
https://chatgpt.com/codex/tasks/task_e_68b5e96b430c832299369b10e3aaa4e7