### PR TITLE
fix(resources): deterministic resource variants

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -12,6 +12,8 @@ import './world_gen/resources/trees.js';
 import './world_gen/resources/bushes.js';
 
 const DEFAULT_CLUSTER_GROWTH = 0.3;
+const RESOURCE_SEED = 0x1234abcd;
+const VARIANT_SEED = 0x5678ef01;
 
 // Biased cluster size picker favors single spawns
 export function pickClusterCount(min, max, rng = Math.random, growthChance = DEFAULT_CLUSTER_GROWTH) {
@@ -141,7 +143,10 @@ function createResourceSystem(scene) {
             let total = 0;
             for (let i = 0; i < centers.length && total < totalTarget; i++) {
                 const c = centers[i];
-                const key = Phaser.Utils.Array.GetRandom(keys);
+                const biome = getBiome(chunk.cx, chunk.cy);
+                const seed = (WORLD_GEN.biomeSeeds[biome] || 0) ^ RESOURCE_SEED;
+                const rKey = getDensity(chunk.cx, chunk.cy, seed);
+                const key = keys[(rKey * keys.length) | 0];
                 const gen = registry.get(key);
                 const cfg = gen && gen();
                 if (!cfg) continue;
@@ -149,10 +154,14 @@ function createResourceSystem(scene) {
                 const clusterRadius = cfg.clusterRadius ?? cfg.minSpacing ?? 50;
                 const clusterMin = cfg.clusterMin ?? 1;
                 const clusterMax = cfg.clusterMax ?? 1;
-                let clusterCount =
-                    Math.random() < clusterChance
-                        ? Phaser.Math.Between(clusterMin, clusterMax)
-                        : 1;
+                const rChance = getDensity(chunk.cx, chunk.cy, seed + 1);
+                let clusterCount = 1;
+                if (rChance < clusterChance) {
+                    const rSize = getDensity(chunk.cx, chunk.cy, seed + 2);
+                    clusterCount =
+                        clusterMin +
+                        ((rSize * (clusterMax - clusterMin + 1)) | 0);
+                }
                 const remaining = totalTarget - total;
                 clusterCount = Math.min(clusterCount, remaining);
                 const cfgOverride = {
@@ -296,8 +305,10 @@ function createResourceSystem(scene) {
             return false;
         };
 
-        const pickVariantId = () => {
-            let r = Math.random() * totalWeight;
+        const pickVariantId = (x, y) => {
+            const biome = biomeFn((x / chunkSize) | 0, (y / chunkSize) | 0);
+            const seed = (WORLD_GEN.biomeSeeds[biome] || 0) ^ VARIANT_SEED;
+            let r = getDensity(x, y, seed) * totalWeight;
             for (let v of variants) {
                 r -= v.weight || 0;
                 if (r <= 0) return v.id;
@@ -643,15 +654,17 @@ function createResourceSystem(scene) {
         };
 
         const spawnCluster = () => {
-            const baseId = pickVariantId();
+            const baseId = pickVariantId(minX, minY);
             const baseKey = baseId.replace(/[A-Za-z0-9]$/, '');
             const baseVariants = variants.filter((v) => v.id.startsWith(baseKey));
             const baseTotalWeight = baseVariants.reduce(
                 (s, v) => s + (v.weight || 0),
                 0,
             );
-            const pickBaseVariant = () => {
-                let r = Math.random() * baseTotalWeight;
+            const pickBaseVariant = (x, y) => {
+                const biome = biomeFn((x / chunkSize) | 0, (y / chunkSize) | 0);
+                const seed = (WORLD_GEN.biomeSeeds[biome] || 0) ^ VARIANT_SEED;
+                let r = getDensity(x, y, seed) * baseTotalWeight;
                 for (const v of baseVariants) {
                     r -= v.weight || 0;
                     if (r <= 0) return v.id;
@@ -659,25 +672,27 @@ function createResourceSystem(scene) {
                 return baseVariants[0].id;
             };
 
-            const firstId = pickBaseVariant();
-            const firstDef = RESOURCE_DB[firstId];
-            if (!firstDef) return 0;
-
-            const firstTex = scene.textures.get(
-                firstDef.world?.textureKey || firstId,
-            );
-            const src = firstTex.getSourceImage();
-            const scale = firstDef.world?.scale ?? 1;
-            const width = src.width * scale;
-            const height = src.height * scale;
-
             let x,
                 y,
                 tries = 30,
-                density = 0;
+                density = 0,
+                firstId,
+                firstDef,
+                width = 0,
+                height = 0;
             do {
                 x = Phaser.Math.Between(minX, maxX);
                 y = Phaser.Math.Between(minY, maxY);
+                firstId = pickBaseVariant(x, y);
+                firstDef = RESOURCE_DB[firstId];
+                if (!firstDef) return 0;
+                const firstTex = scene.textures.get(
+                    firstDef.world?.textureKey || firstId,
+                );
+                const src = firstTex.getSourceImage();
+                const scale = firstDef.world?.scale ?? 1;
+                width = src.width * scale;
+                height = src.height * scale;
                 const biome = biomeFn((x / chunkSize) | 0, (y / chunkSize) | 0);
                 const seed = WORLD_GEN.biomeSeeds[biome] || 0;
                 density = densityFn(x, y, seed);
@@ -701,20 +716,14 @@ function createResourceSystem(scene) {
                 i < clusterCount && scene.resources.countActive(true) < maxActive;
                 i++
             ) {
-                const id = pickBaseVariant();
-                const def = RESOURCE_DB[id];
-                if (!def) continue;
-
-                const tex = scene.textures.get(def.world?.textureKey || id);
-                const src2 = tex.getSourceImage();
-                const scale2 = def.world?.scale ?? 1;
-                const w = src2.width * scale2;
-                const h = src2.height * scale2;
-
                 let x2,
                     y2,
                     t2 = 10,
-                    d2 = 0;
+                    d2 = 0,
+                    id,
+                    def,
+                    w = 0,
+                    h = 0;
                 do {
                     const ang = Phaser.Math.FloatBetween(0, Math.PI * 2);
                     const dist = Phaser.Math.FloatBetween(
@@ -723,12 +732,20 @@ function createResourceSystem(scene) {
                     );
                     x2 = x + Math.cos(ang) * dist;
                     y2 = y + Math.sin(ang) * dist;
+                    id = pickBaseVariant(x2, y2);
+                    def = RESOURCE_DB[id];
+                    if (!def) break;
+                    const tex = scene.textures.get(def.world?.textureKey || id);
+                    const src2 = tex.getSourceImage();
+                    const scale2 = def.world?.scale ?? 1;
+                    w = src2.width * scale2;
+                    h = src2.height * scale2;
                     const biome2 = biomeFn((x2 / chunkSize) | 0, (y2 / chunkSize) | 0);
                     const seed2 = WORLD_GEN.biomeSeeds[biome2] || 0;
                     d2 = densityFn(x2, y2, seed2);
                     t2--;
                 } while (t2 > 0 && (d2 < 0.5 || tooClose(x2, y2, w, h)));
-                if (t2 <= 0) continue;
+                if (t2 <= 0 || !def) continue;
                 createResourceAt(id, def, x2, y2);
                 spawned++;
             }

--- a/test/systems/resourceClusterSpawn.test.js
+++ b/test/systems/resourceClusterSpawn.test.js
@@ -1,20 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-// Stub Phaser math utilities
+// Stub Phaser math utilities with deterministic sequence
+const seq = [80, 160, 0, 21, Math.PI / 2, 21];
+let si = 0;
 globalThis.Phaser = {
     Math: {
-        Between: (min, max) => Math.floor(min + (max - min) * Math.random()),
-        FloatBetween: (min, max) => min + (max - min) * Math.random(),
+        Between: () => seq[si++],
+        FloatBetween: () => seq[si++],
     },
 };
 
-// Deterministic RNG sequence
-const randSeq = [0.1, 0.2, 0.1, 0.1, 0.3, 0.0, 1.0, 0.4, 0.5, 1.0];
-let ri = 0;
-
-test('clusters spawn same base type without overlap', async (t) => {
-    t.mock.method(Math, 'random', () => randSeq[ri++ % randSeq.length]);
+test('clusters spawn same base type without overlap', async () => {
 
     const { default: createResourceSystem } = await import('../../systems/resourceSystem.js');
 


### PR DESCRIPTION
## Summary
- derive resource keys and cluster sizes from chunk coordinates
- select resource variants using position-based noise

## Technical Approach
- `systems/resourceSystem.js` `spawnChunkResources` and `_spawnResourceGroup`
- `test/systems/resourceClusterSpawn.test.js`

## Performance
- coordinate hashing only; avoids per-frame allocations

## Risks & Rollback
- resource distribution may shift; revert commit `f58d56c` if issues arise

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5eeb629388322b8c5d19c4fbcdd8a