### PR TITLE
fix(camera): remove pixel rounding jitter

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -34,7 +34,7 @@ if (IS_NODE) {
         render: {
             pixelArt: true,      // use nearest-neighbor sampling (no smoothing)
             antialias: false,    // disable texture smoothing on Canvas
-            roundPixels: true,   // snap draws to whole pixels to avoid shimmering
+            roundPixels: false,  // allow smooth sub-pixel camera movement
             powerPreference: 'high-performance',
         },
 

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -157,8 +157,8 @@ export default class MainScene extends Phaser.Scene {
             .setDepth(900)
             .setCollideWorldBounds(false);
 
-        this.cameras.main.startFollow(this.player, true);
-        this.cameras.main.setRoundPixels(true);
+        this.cameras.main.startFollow(this.player);
+        this.cameras.main.setRoundPixels(false);
 
         this.player._speedMult = 1;
         this.player._inBush = false;


### PR DESCRIPTION
## Summary
- disable renderer and camera roundPixels settings to smooth side-to-side movement

## Technical Approach
- set `render.roundPixels` to false in `bootstrap.js`
- follow the player without rounding in `MainScene.create`

## Performance
- no per-frame allocations added; only config adjustments

## Risks & Rollback
- potential for sub-pixel shimmering; revert commit `5f9dfae` to restore prior rounding

## QA
- `npm test`
- run the game and strafe left/right; confirm movement is smooth without jitter

------
https://chatgpt.com/codex/tasks/task_e_68b5f46f8998832295429e1cc22020ed