### PR TITLE
feat: spawn resource clusters as piles

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -659,15 +659,14 @@ function createResourceSystem(scene) {
                 return baseVariants[0].id;
             };
 
-            const firstId = pickBaseVariant();
-            const firstDef = RESOURCE_DB[firstId];
-            if (!firstDef) return 0;
+            const baseDef = RESOURCE_DB[baseId];
+            if (!baseDef) return 0;
 
-            const firstTex = scene.textures.get(
-                firstDef.world?.textureKey || firstId,
+            const baseTex = scene.textures.get(
+                baseDef.world?.textureKey || baseId,
             );
-            const src = firstTex.getSourceImage();
-            const scale = firstDef.world?.scale ?? 1;
+            const src = baseTex.getSourceImage();
+            const scale = baseDef.world?.scale ?? 1;
             const width = src.width * scale;
             const height = src.height * scale;
 
@@ -685,7 +684,7 @@ function createResourceSystem(scene) {
             } while (tries > 0 && (density < 0.5 || tooClose(x, y, width, height)));
             if (tries <= 0) return 0;
 
-            createResourceAt(firstId, firstDef, x, y);
+            createResourceAt(baseId, baseDef, x, y);
             let spawned = 1;
             const growthChance = groupCfg.clusterGrowth ?? DEFAULT_CLUSTER_GROWTH;
             const clusterCount = pickClusterCount(
@@ -717,10 +716,7 @@ function createResourceSystem(scene) {
                     d2 = 0;
                 do {
                     const ang = Phaser.Math.FloatBetween(0, Math.PI * 2);
-                    const dist = Phaser.Math.FloatBetween(
-                        Math.max(width, height),
-                        radius,
-                    );
+                    const dist = radius * Math.sqrt(Math.random());
                     x2 = x + Math.cos(ang) * dist;
                     y2 = y + Math.sin(ang) * dist;
                     const biome2 = biomeFn((x2 / chunkSize) | 0, (y2 / chunkSize) | 0);


### PR DESCRIPTION
## Summary
- place additional cluster resources within a circle for a pile-like look
- keep cluster members to a single base variant and remove duplicate `firstId`

## Technical Approach
- `systems/resourceSystem.js` `_spawnResourceGroup.spawnCluster` picks a base variant once, distributes members radially, and reuses that id for the first spawn
- `test/systems/resourceClusterSpawn.test.js` ensures all cluster members share a prefix and stay within radius

## Performance
- calculations run only during spawn; no per-frame allocations

## Risks & Rollback
- dense areas may incur extra retries; revert commit `e96ad01` if clustering misbehaves

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ee11a88c8322adbb4a9adf72bf70