### PR TITLE
fix(resource-system): prevent width redeclaration error

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -675,16 +675,6 @@ function createResourceSystem(scene) {
             const baseDef = RESOURCE_DB[baseId];
             if (!baseDef) return 0;
 
-            const baseTex = scene.textures.get(
-                baseDef.world?.textureKey || baseId,
-            );
-          
-            // derive width/height from base variant for spacing
-            const baseSrc = baseTex.getSourceImage();
-            const baseScale = baseDef.world?.scale ?? 1;
-            const width = baseSrc.width * baseScale;
-            const height = baseSrc.height * baseScale;
-
             let x,
                 y,
                 tries = 30,


### PR DESCRIPTION
Summary:
- Remove redundant width/height declarations causing a SyntaxError during resource spawning.

Technical Approach:
- systems/resourceSystem.js: drop unused base texture sizing block so width/height are only declared once in spawnCluster.

Performance:
- No additional per-frame allocations; unchanged runtime behavior.

Risks & Rollback:
- Low risk: resource spawn spacing still governed by first variant dimensions.
- Rollback by reverting commit 863a7ee.

QA Steps:
- `npm test`
- Launch game and ensure no "Identifier 'width' has already been declared" error in console when spawning resources.


------
https://chatgpt.com/codex/tasks/task_e_68b5f7c3bab08322a13156720dd0d849