### PR TITLE
fix(render): enable pixel rounding

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -34,7 +34,7 @@ if (IS_NODE) {
         render: {
             pixelArt: true,      // use nearest-neighbor sampling (no smoothing)
             antialias: false,    // disable texture smoothing on Canvas
-            roundPixels: false,  // allow smooth sub-pixel camera movement
+            roundPixels: true,   // force integer pixel positions for crisp movement
             powerPreference: 'high-performance',
         },
 

--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -158,7 +158,7 @@ export default class MainScene extends Phaser.Scene {
             .setCollideWorldBounds(false);
 
         this.cameras.main.startFollow(this.player);
-        this.cameras.main.setRoundPixels(false);
+        this.cameras.main.setRoundPixels(true);
 
         this.player._speedMult = 1;
         this.player._inBush = false;

--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -29,6 +29,7 @@ export default class UIScene extends Phaser.Scene {
     }
 
     create() {
+        this.cameras.main.setRoundPixels(true);
         // -------------------------
         // Inventory model (logic)
         // -------------------------


### PR DESCRIPTION
## Summary
- enable camera pixel rounding for crisper pixel art

## Technical Approach
- set `render.roundPixels` to `true` in `bootstrap.js`
- call `setRoundPixels(true)` in `MainScene` and `UIScene` cameras

## Performance
- uses static configuration; no per-frame allocations

## Risks & Rollback
- minimal risk; revert commit if rendering issues appear

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b64772484483228ada61b3b918ca6f