### PR TITLE
feat: render biome-colored chunk backgrounds

### DIFF
--- a/systems/world_gen/chunks/Chunk.js
+++ b/systems/world_gen/chunks/Chunk.js
@@ -2,6 +2,7 @@
 // Basic world chunk container handling entity group and metadata.
 
 import { WORLD_GEN } from '../worldGenConfig.js';
+import { getBiome } from '../biomes/biomeMap.js';
 
 export default class Chunk {
     constructor(cx, cy, meta = {}) {
@@ -9,6 +10,7 @@ export default class Chunk {
         this.cy = cy;
         this.group = null;
         this.meta = meta;
+        this.rect = null;
     }
 
     load(scene) {
@@ -16,6 +18,18 @@ export default class Chunk {
             this.group = scene.add.group();
         }
         this.group.active = true;
+        if (!this.rect) {
+            const size = WORLD_GEN.chunk.size;
+            const color = WORLD_GEN.biomeColors[getBiome(this.cx, this.cy)];
+            this.rect = scene.add.rectangle(
+                this.cx * size,
+                this.cy * size,
+                size,
+                size,
+                color,
+            ).setOrigin(0, 0).setDepth(-1);
+            this.group.add(this.rect);
+        }
         if (Array.isArray(this.meta.zombies) && this.meta.zombies.length > 0) {
             if (scene?.combat?.spawnZombie) {
                 for (const z of this.meta.zombies) {
@@ -29,6 +43,10 @@ export default class Chunk {
     }
 
     unload(scene) {
+        if (this.rect) {
+            this.rect.destroy();
+            this.rect = null;
+        }
         if (this.group) {
             const children = this.group.getChildren ? this.group.getChildren() : [];
             for (let i = 0; i < children.length; i++) {

--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -32,6 +32,13 @@ export const WORLD_GEN = {
     [BIOME_IDS.DESERT]: 13579,
   },
 
+  // Debug fill colors for biome backgrounds
+  biomeColors: {
+    [BIOME_IDS.PLAINS]: 0x228B22,
+    [BIOME_IDS.FOREST]: 0x8B4513,
+    [BIOME_IDS.DESERT]: 0xFFD700,
+  },
+
   // -----------------------------
   // Day/Night cycle (arcade-style)
   // -----------------------------

--- a/test/systems/world_gen/Chunk.test.js
+++ b/test/systems/world_gen/Chunk.test.js
@@ -1,0 +1,74 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import Chunk from '../../../systems/world_gen/chunks/Chunk.js';
+import { BIOME_IDS, WORLD_GEN } from '../../../systems/world_gen/worldGenConfig.js';
+
+function mockScene(rectCb) {
+    return {
+        add: {
+            group: () => ({
+                active: true,
+                add() {},
+                getChildren: () => [],
+                clear() {},
+            }),
+            rectangle: rectCb,
+        },
+        resourcePool: { release() {} },
+    };
+}
+
+test('Chunk load draws biome-colored rectangle', () => {
+    const size = WORLD_GEN.chunk.size;
+    const cases = [
+        { cx: 0, cy: 0, biome: BIOME_IDS.PLAINS },
+        { cx: 8, cy: 8, biome: BIOME_IDS.FOREST },
+        { cx: 1, cy: 1, biome: BIOME_IDS.DESERT },
+    ];
+
+    for (const { cx, cy, biome } of cases) {
+        const rects = [];
+        const scene = mockScene((x, y, w, h, color) => {
+            rects.push({ x, y, w, h, color });
+            return {
+                setOrigin() { return this; },
+                setDepth() { return this; },
+                destroy() {},
+            };
+        });
+        const chunk = new Chunk(cx, cy);
+        chunk.load(scene);
+        assert.equal(rects.length, 1);
+        assert.equal(rects[0].x, cx * size);
+        assert.equal(rects[0].y, cy * size);
+        assert.equal(rects[0].w, size);
+        assert.equal(rects[0].h, size);
+        assert.equal(rects[0].color, WORLD_GEN.biomeColors[biome]);
+        chunk.unload(scene);
+        assert.equal(chunk.rect, null);
+    }
+});
+
+test('Rectangles only created on load and destroyed on unload', () => {
+    let createCount = 0;
+    let destroyCount = 0;
+    const scene = mockScene(() => {
+        createCount++;
+        return {
+            setOrigin() { return this; },
+            setDepth() { return this; },
+            destroy() { destroyCount++; },
+        };
+    });
+    const chunk = new Chunk(0, 0);
+    chunk.load(scene);
+    assert.equal(createCount, 1);
+    chunk.load(scene);
+    assert.equal(createCount, 1);
+    chunk.unload(scene);
+    assert.equal(destroyCount, 1);
+    chunk.load(scene);
+    assert.equal(createCount, 2);
+});
+

--- a/test/systems/world_gen/chunkManager.test.js
+++ b/test/systems/world_gen/chunkManager.test.js
@@ -8,7 +8,20 @@ import { WORLD_GEN } from '../../../systems/world_gen/worldGenConfig.js';
 test('ChunkManager loads and unloads chunks around player movement', () => {
     const scene = {
         events: new EventEmitter(),
-        add: { group: () => ({ active: true, destroy() {} }) },
+        add: {
+            group: () => ({
+                active: true,
+                add() {},
+                getChildren: () => [],
+                clear() {},
+                destroy() {},
+            }),
+            rectangle: () => ({
+                setOrigin() { return this; },
+                setDepth() { return this; },
+                destroy() {},
+            }),
+        },
     };
     const cm = new ChunkManager(scene, 1);
     cm.maxLoadsPerTick = 9;
@@ -34,7 +47,20 @@ test('ChunkManager loads and unloads chunks around player movement', () => {
 test('ChunkManager wraps coordinates across world bounds', () => {
     const scene = {
         events: new EventEmitter(),
-        add: { group: () => ({ active: true, destroy() {} }) },
+        add: {
+            group: () => ({
+                active: true,
+                add() {},
+                getChildren: () => [],
+                clear() {},
+                destroy() {},
+            }),
+            rectangle: () => ({
+                setOrigin() { return this; },
+                setDepth() { return this; },
+                destroy() {},
+            }),
+        },
     };
     const cm = new ChunkManager(scene, 1);
     cm.maxLoadsPerTick = 9;


### PR DESCRIPTION
### Summary
- tint chunk backgrounds using biome colors
- draw rectangle per chunk on load and clean up on unload
- cover chunk coloring with unit tests

### Technical Approach
- `systems/world_gen/worldGenConfig.js` maps biome IDs to colors
- `systems/world_gen/chunks/Chunk.js` spawns a biome-colored rectangle and destroys it on unload
- tests mock `scene.add.rectangle` to assert color and lifecycle

### Performance
- rectangles allocated once per chunk load; destroyed on unload to avoid leaks
- no per-frame allocations added

### Risks & Rollback
- incorrect color mapping or depth layering could hide entities; revert commit to restore previous visuals

### QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b649f6afbc8322af594740cf3ce446