### PR TITLE
feat: add biome gradient chunk textures

### DIFF
--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -30,6 +30,9 @@ export const WORLD_GEN = {
   // -----------------------------
   chunk: {
     size: 500,
+    // Biome color blending (chunk backgrounds)
+    blendRadius: 50, // pixels between biome samples
+    blendFalloff: 1.0, // reserved for future weighting logic
   },
 
   // Biome-specific RNG seeds

--- a/test/systems/world_gen/Chunk.test.js
+++ b/test/systems/world_gen/Chunk.test.js
@@ -1,11 +1,11 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
 
-import Chunk from '../../../systems/world_gen/chunks/Chunk.js';
+import Chunk, { __clearTexturePool } from '../../../systems/world_gen/chunks/Chunk.js';
 import { WORLD_GEN } from '../../../systems/world_gen/worldGenConfig.js';
 import { getBiome } from '../../../systems/world_gen/biomes/biomeMap.js';
 
-function mockScene(rectCb) {
+function mockScene(rtCb) {
     return {
         add: {
             group: () => ({
@@ -13,14 +13,16 @@ function mockScene(rectCb) {
                 add() {},
                 getChildren: () => [],
                 clear() {},
+                remove() {},
             }),
-            rectangle: rectCb,
+            renderTexture: rtCb,
         },
         resourcePool: { release() {} },
     };
 }
 
-test('Chunk load draws biome-colored rectangle', () => {
+test('Chunk load draws biome render texture', () => {
+    __clearTexturePool();
     const size = WORLD_GEN.chunk.size;
     const cases = [
         { cx: 0, cy: 0 },
@@ -30,37 +32,49 @@ test('Chunk load draws biome-colored rectangle', () => {
 
     for (const { cx, cy } of cases) {
         const biome = getBiome(cx, cy);
-        const rects = [];
-        const scene = mockScene((x, y, w, h, color) => {
-            rects.push({ x, y, w, h, color });
+        const calls = [];
+        const scene = mockScene((x, y, w, h) => {
             return {
+                fills: [],
                 setOrigin() { return this; },
                 setDepth() { return this; },
-                destroy() {},
+                setVisible() { return this; },
+                setActive() { return this; },
+                setPosition(nx, ny) { x = nx; y = ny; return this; },
+                clear() { this.fills = []; return this; },
+                fill(color, alpha, rx, ry, rw, rh) { this.fills.push(color); },
+                get x() { return x; },
+                get y() { return y; },
+                get width() { return w; },
+                get height() { return h; },
             };
         });
         const chunk = new Chunk(cx, cy);
         chunk.load(scene);
-        assert.equal(rects.length, 1);
-        assert.equal(rects[0].x, cx * size);
-        assert.equal(rects[0].y, cy * size);
-        assert.equal(rects[0].w, size);
-        assert.equal(rects[0].h, size);
-        assert.equal(rects[0].color, WORLD_GEN.biomeColors[biome]);
+        const tex = chunk.rt;
+        assert.equal(tex.x, cx * size);
+        assert.equal(tex.y, cy * size);
+        assert.equal(tex.width, size);
+        assert.equal(tex.height, size);
+        assert.equal(tex.fills[0], WORLD_GEN.biomeColors[biome]);
         chunk.unload(scene);
-        assert.equal(chunk.rect, null);
+        assert.equal(chunk.rt, null);
     }
 });
 
-test('Rectangles only created on load and destroyed on unload', () => {
+test('RenderTextures only created once and pooled on unload', () => {
+    __clearTexturePool();
     let createCount = 0;
-    let destroyCount = 0;
     const scene = mockScene(() => {
         createCount++;
         return {
             setOrigin() { return this; },
             setDepth() { return this; },
-            destroy() { destroyCount++; },
+            setVisible() { return this; },
+            setActive() { return this; },
+            setPosition() { return this; },
+            clear() { return this; },
+            fill() {},
         };
     });
     const chunk = new Chunk(0, 0);
@@ -69,8 +83,7 @@ test('Rectangles only created on load and destroyed on unload', () => {
     chunk.load(scene);
     assert.equal(createCount, 1);
     chunk.unload(scene);
-    assert.equal(destroyCount, 1);
     chunk.load(scene);
-    assert.equal(createCount, 2);
+    assert.equal(createCount, 1);
 });
 

--- a/test/systems/world_gen/chunkManager.test.js
+++ b/test/systems/world_gen/chunkManager.test.js
@@ -15,11 +15,16 @@ test('ChunkManager loads and unloads chunks around player movement', () => {
                 getChildren: () => [],
                 clear() {},
                 destroy() {},
+                remove() {},
             }),
-            rectangle: () => ({
+            renderTexture: () => ({
                 setOrigin() { return this; },
                 setDepth() { return this; },
-                destroy() {},
+                setVisible() { return this; },
+                setActive() { return this; },
+                setPosition() { return this; },
+                clear() { return this; },
+                fill() {},
             }),
         },
     };
@@ -54,11 +59,16 @@ test('ChunkManager wraps coordinates across world bounds', () => {
                 getChildren: () => [],
                 clear() {},
                 destroy() {},
+                remove() {},
             }),
-            rectangle: () => ({
+            renderTexture: () => ({
                 setOrigin() { return this; },
                 setDepth() { return this; },
-                destroy() {},
+                setVisible() { return this; },
+                setActive() { return this; },
+                setPosition() { return this; },
+                clear() { return this; },
+                fill() {},
             }),
         },
     };


### PR DESCRIPTION
Summary:
- Pre-render chunk backgrounds with biome color gradients and texture pooling.

Technical Approach:
- systems/world_gen/chunks/Chunk.js
- systems/world_gen/worldGenConfig.js
- test/systems/world_gen/Chunk.test.js
- test/systems/world_gen/chunkManager.test.js

Performance:
- Generates textures once per chunk and reuses pooled RenderTextures, avoiding per-frame allocations.

Risks & Rollback:
- Texture pooling may retain hidden objects; clear TEX_POOL via __clearTexturePool or revert commit.

QA Steps:
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68b65745718c8322a7d2acbec4b0ab32