### PR TITLE
feat: add pixelated biome gradient chunk textures

### DIFF
--- a/systems/world_gen/chunks/Chunk.js
+++ b/systems/world_gen/chunks/Chunk.js
@@ -4,13 +4,54 @@
 import { WORLD_GEN } from '../worldGenConfig.js';
 import { getBiome } from '../biomes/biomeMap.js';
 
+const TEX_POOL = [];
+
+function avgColor(tl, tr, bl, br) {
+    const r = (((tl >> 16) & 0xff)
+        + ((tr >> 16) & 0xff)
+        + ((bl >> 16) & 0xff)
+        + ((br >> 16) & 0xff)) >> 2;
+    const g = (((tl >> 8) & 0xff)
+        + ((tr >> 8) & 0xff)
+        + ((bl >> 8) & 0xff)
+        + ((br >> 8) & 0xff)) >> 2;
+    const b = ((tl & 0xff)
+        + (tr & 0xff)
+        + (bl & 0xff)
+        + (br & 0xff)) >> 2;
+    return (r << 16) | (g << 8) | b;
+}
+
+function drawBiomeTexture(scene, rt, cx, cy) {
+    const size = WORLD_GEN.chunk.size;
+    const radius = WORLD_GEN.chunk.blendRadius ?? 50;
+    const samples = Math.max(2, Math.floor(size / radius));
+    const step = size / samples;
+    const g = scene.add.graphics();
+    for (let ix = 0; ix < samples; ix++) {
+        for (let iy = 0; iy < samples; iy++) {
+            const x = cx + ix / samples;
+            const y = cy + iy / samples;
+            const tl = WORLD_GEN.biomeColors[getBiome(x, y)];
+            const tr = WORLD_GEN.biomeColors[getBiome(x + 1 / samples, y)];
+            const bl = WORLD_GEN.biomeColors[getBiome(x, y + 1 / samples)];
+            const br = WORLD_GEN.biomeColors[getBiome(x + 1 / samples, y + 1 / samples)];
+            const color = avgColor(tl, tr, bl, br);
+            g.fillStyle(color, 1);
+            g.fillRect(ix * step, iy * step, step + 1, step + 1);
+        }
+    }
+    rt.draw(g);
+    g.destroy();
+}
+
 export default class Chunk {
     constructor(cx, cy, meta = {}) {
         this.cx = cx;
         this.cy = cy;
         this.group = null;
         this.meta = meta;
-        this.rect = null;
+        this.rt = null;
     }
 
     load(scene) {
@@ -18,17 +59,23 @@ export default class Chunk {
             this.group = scene.add.group();
         }
         this.group.active = true;
-        if (!this.rect) {
+        if (!this.rt) {
             const size = WORLD_GEN.chunk.size;
-            const color = WORLD_GEN.biomeColors[getBiome(this.cx, this.cy)];
-            this.rect = scene.add.rectangle(
-                this.cx * size,
-                this.cy * size,
-                size,
-                size,
-                color,
-            ).setOrigin(0, 0).setDepth(-1);
-            this.group.add(this.rect);
+            let tex = TEX_POOL.pop();
+            if (tex) {
+                tex.setPosition(this.cx * size, this.cy * size);
+                tex.setVisible(true).setActive(true).clear();
+            } else {
+                tex = scene.add.renderTexture(
+                    this.cx * size,
+                    this.cy * size,
+                    size,
+                    size,
+                ).setOrigin(0, 0).setDepth(-1);
+            }
+            drawBiomeTexture(scene, tex, this.cx, this.cy);
+            this.group.add(tex);
+            this.rt = tex;
         }
         if (Array.isArray(this.meta.zombies) && this.meta.zombies.length > 0) {
             if (scene?.combat?.spawnZombie) {
@@ -43,9 +90,13 @@ export default class Chunk {
     }
 
     unload(scene) {
-        if (this.rect) {
-            this.rect.destroy();
-            this.rect = null;
+        if (this.rt) {
+            this.group?.remove(this.rt, false);
+            this.rt.clear();
+            this.rt.setVisible(false);
+            this.rt.setActive(false);
+            TEX_POOL.push(this.rt);
+            this.rt = null;
         }
         if (this.group) {
             const children = this.group.getChildren ? this.group.getChildren() : [];
@@ -88,5 +139,9 @@ export default class Chunk {
             meta: { ...this.meta },
         };
     }
+}
+
+export function __clearTexturePool() {
+    TEX_POOL.length = 0;
 }
 

--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -30,6 +30,9 @@ export const WORLD_GEN = {
   // -----------------------------
   chunk: {
     size: 500,
+    // Biome color blending (chunk backgrounds)
+    blendRadius: 50, // pixels between biome samples
+    blendFalloff: 1.0, // reserved for future weighting logic
   },
 
   // Biome-specific RNG seeds

--- a/test/systems/world_gen/Chunk.test.js
+++ b/test/systems/world_gen/Chunk.test.js
@@ -1,26 +1,45 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
 
-import Chunk from '../../../systems/world_gen/chunks/Chunk.js';
+import Chunk, { __clearTexturePool } from '../../../systems/world_gen/chunks/Chunk.js';
 import { WORLD_GEN } from '../../../systems/world_gen/worldGenConfig.js';
 import { getBiome } from '../../../systems/world_gen/biomes/biomeMap.js';
 
-function mockScene(rectCb) {
-    return {
+function mockScene(rtCb) {
+    const graphicsCalls = [];
+    const scene = {
         add: {
             group: () => ({
                 active: true,
                 add() {},
                 getChildren: () => [],
                 clear() {},
+                remove() {},
             }),
-            rectangle: rectCb,
+            renderTexture: rtCb,
+            graphics: () => {
+                const g = {
+                    fills: [],
+                    fillStyle(color) {
+                        this.fills.push(color);
+                        return this;
+                    },
+                    fillRect() { return this; },
+                    clear() { return this; },
+                    destroy() { return this; },
+                };
+                graphicsCalls.push(g);
+                return g;
+            },
         },
         resourcePool: { release() {} },
+        _graphicsCalls: graphicsCalls,
     };
+    return scene;
 }
 
-test('Chunk load draws biome-colored rectangle', () => {
+test('Chunk load draws biome render texture', () => {
+    __clearTexturePool();
     const size = WORLD_GEN.chunk.size;
     const cases = [
         { cx: 0, cy: 0 },
@@ -30,37 +49,50 @@ test('Chunk load draws biome-colored rectangle', () => {
 
     for (const { cx, cy } of cases) {
         const biome = getBiome(cx, cy);
-        const rects = [];
-        const scene = mockScene((x, y, w, h, color) => {
-            rects.push({ x, y, w, h, color });
+        const scene = mockScene((x, y, w, h) => {
             return {
+                draws: 0,
                 setOrigin() { return this; },
                 setDepth() { return this; },
-                destroy() {},
+                setVisible() { return this; },
+                setActive() { return this; },
+                setPosition(nx, ny) { x = nx; y = ny; return this; },
+                clear() { return this; },
+                draw() { this.draws++; return this; },
+                get x() { return x; },
+                get y() { return y; },
+                get width() { return w; },
+                get height() { return h; },
             };
         });
         const chunk = new Chunk(cx, cy);
         chunk.load(scene);
-        assert.equal(rects.length, 1);
-        assert.equal(rects[0].x, cx * size);
-        assert.equal(rects[0].y, cy * size);
-        assert.equal(rects[0].w, size);
-        assert.equal(rects[0].h, size);
-        assert.equal(rects[0].color, WORLD_GEN.biomeColors[biome]);
+        const tex = chunk.rt;
+        assert.equal(tex.x, cx * size);
+        assert.equal(tex.y, cy * size);
+        assert.equal(tex.width, size);
+        assert.equal(tex.height, size);
+        assert.ok(tex.draws > 0);
+        const fills = scene._graphicsCalls[0].fills;
+        assert(fills.includes(WORLD_GEN.biomeColors[biome]));
         chunk.unload(scene);
-        assert.equal(chunk.rect, null);
+        assert.equal(chunk.rt, null);
     }
 });
 
-test('Rectangles only created on load and destroyed on unload', () => {
+test('RenderTextures only created once and pooled on unload', () => {
+    __clearTexturePool();
     let createCount = 0;
-    let destroyCount = 0;
     const scene = mockScene(() => {
         createCount++;
         return {
             setOrigin() { return this; },
             setDepth() { return this; },
-            destroy() { destroyCount++; },
+            setVisible() { return this; },
+            setActive() { return this; },
+            setPosition() { return this; },
+            clear() { return this; },
+            draw() {},
         };
     });
     const chunk = new Chunk(0, 0);
@@ -69,8 +101,7 @@ test('Rectangles only created on load and destroyed on unload', () => {
     chunk.load(scene);
     assert.equal(createCount, 1);
     chunk.unload(scene);
-    assert.equal(destroyCount, 1);
     chunk.load(scene);
-    assert.equal(createCount, 2);
+    assert.equal(createCount, 1);
 });
 

--- a/test/systems/world_gen/chunkManager.test.js
+++ b/test/systems/world_gen/chunkManager.test.js
@@ -15,11 +15,22 @@ test('ChunkManager loads and unloads chunks around player movement', () => {
                 getChildren: () => [],
                 clear() {},
                 destroy() {},
+                remove() {},
             }),
-            rectangle: () => ({
+            renderTexture: () => ({
                 setOrigin() { return this; },
                 setDepth() { return this; },
-                destroy() {},
+                setVisible() { return this; },
+                setActive() { return this; },
+                setPosition() { return this; },
+                clear() { return this; },
+                draw() {},
+            }),
+            graphics: () => ({
+                fillStyle() { return this; },
+                fillRect() { return this; },
+                clear() { return this; },
+                destroy() { return this; },
             }),
         },
     };
@@ -54,11 +65,22 @@ test('ChunkManager wraps coordinates across world bounds', () => {
                 getChildren: () => [],
                 clear() {},
                 destroy() {},
+                remove() {},
             }),
-            rectangle: () => ({
+            renderTexture: () => ({
                 setOrigin() { return this; },
                 setDepth() { return this; },
-                destroy() {},
+                setVisible() { return this; },
+                setActive() { return this; },
+                setPosition() { return this; },
+                clear() { return this; },
+                draw() {},
+            }),
+            graphics: () => ({
+                fillStyle() { return this; },
+                fillRect() { return this; },
+                clear() { return this; },
+                destroy() { return this; },
             }),
         },
     };


### PR DESCRIPTION
Summary:
- Pre-render chunk backgrounds with blocky biome color blending to fade into neighboring regions while keeping a pixel-art look.

Technical Approach:
- systems/world_gen/chunks/Chunk.js
- test/systems/world_gen/Chunk.test.js
- test/systems/world_gen/chunkManager.test.js

Performance:
- Generates textures once per chunk and reuses pooled RenderTextures, avoiding per-frame allocations.

Risks & Rollback:
- Averaged colors may produce unexpected hues; revert commit `b1db364` to remove.

QA Steps:
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68b65745718c8322a7d2acbec4b0ab32