### PR TITLE
fix: prevent resource overlap in clusters

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -179,7 +179,7 @@ function createResourceSystem(scene) {
                     clusterMin: clusterCount,
                     clusterMax: clusterCount,
                     clusterRadius,
-                    minSpacing: clusterCount > 1 ? 0 : cfg.minSpacing,
+                    minSpacing: cfg.minSpacing,
                 };
                 const spawned =
                     _spawnResourceGroup(key, cfgOverride, {


### PR DESCRIPTION
## Summary
- keep min spacing when spawning clustered resources to avoid overlap

## Technical Approach
- remove minSpacing override in `resourceSystem.js` so clusters respect configured spacing

## Performance
- no per-frame allocations; uses existing spawn checks

## Risks & Rollback
- clusters may spawn fewer resources if area is too tight
- rollback by reverting `systems/resourceSystem.js`

## QA Steps
- run `npm test`
- start game and verify resources no longer overlap when spawned


------
https://chatgpt.com/codex/tasks/task_e_68b66f07567483228d517e1a7711523d