### PR TITLE
fix: hide decor sprites from hitbox debug overlay

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -571,6 +571,7 @@ const DevTools = {
             for (let i = 0; i < list.length; i++) {
                 const obj = list[i];
                 if (!obj || !obj.active || !obj.visible) continue;
+                if (obj.getData && obj.getData('noHitboxDebug')) continue;
                 const body = obj.body;
                 if (body) {
                     if (body.isCircle) {

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -388,6 +388,7 @@ function createResourceSystem(scene) {
                     .setDepth((scene.player?.depth ?? 900) + 2 + depthOff)
                     .setCrop(0, 0, frameW, topH);
                 scene.resourcesDecor && scene.resourcesDecor.add(top);
+                top.setData('noHitboxDebug', true);
                 trunk.setCrop(0, topH, frameW, frameH - topH);
                 trunk.setData('topSprite', top);
                 trunk.once('destroy', () => top.destroy());
@@ -548,6 +549,7 @@ function createResourceSystem(scene) {
                     .setDepth((def.leavesDepth ?? def.depth ?? 5) + depthOff)
                     .setCrop(cropX, cropY, lw, lh);
                 scene.resourcesDecor && scene.resourcesDecor.add(leaves);
+                leaves.setData('noHitboxDebug', true);
 
                 const dispW = trunk.displayWidth;
                 const dispH = trunk.displayHeight;


### PR DESCRIPTION
### Summary
- prevent decorative tree leaves and rock tops from adding extra hitbox visuals

### Technical Approach
- mark decorative sprites with `noHitboxDebug` in `resourceSystem`
- skip flagged sprites when drawing resource hitboxes in `DevTools`

### Performance
- single flag check per resource; no allocations

### Risks & Rollback
- only affects debug visualization; revert commit 8754692 if hitboxes disappear unexpectedly

### QA Steps
- toggle DevTools' showHitboxes
- inspect trees and rocks: only small trunk/rock body boxes appear, no large overlay boxes

------
https://chatgpt.com/codex/tasks/task_e_68b6700266cc8322b462dcf3fb46c079