### PR TITLE
fix: smooth corner biome blending

### DIFF
--- a/systems/world_gen/chunks/Chunk.js
+++ b/systems/world_gen/chunks/Chunk.js
@@ -43,21 +43,50 @@ function drawBiomeTexture(scene, rt, cx, cy) {
             const py = (iy + 0.5) * step;
             const worldX = cx * size + px;
             const worldY = cy * size + py;
-            const edgeDist = Math.min(px, py, size - px, size - py);
             const jitter = sampleBiomeNoise(worldX * noiseScale, worldY * noiseScale) * jitterAmt;
-            const dist = edgeDist + jitter;
-            let color = baseColor;
-            if (dist < radius) {
-                let nx = cx;
-                let ny = cy;
-                if (px < radius) nx = cx - 1;
-                else if (px > size - radius) nx = cx + 1;
-                if (py < radius) ny = cy - 1;
-                else if (py > size - radius) ny = cy + 1;
-                const neighborColor = WORLD_GEN.biomeColors[getBiome(nx + 0.5, ny + 0.5)];
-                const t = Math.pow(1 - dist / radius, falloff) * 0.5;
-                color = lerpColor(baseColor, neighborColor, t);
+            const distX = Math.min(px, size - px) + jitter;
+            const distY = Math.min(py, size - py) + jitter;
+
+            // Accumulate weighted RGB contributions from neighbouring biomes.
+            let r = (baseColor >> 16) & 0xff;
+            let gcol = (baseColor >> 8) & 0xff;
+            let bcol = baseColor & 0xff;
+            let weight = 1;
+
+            let tX = 0;
+            let tY = 0;
+            if (distX < radius) {
+                const nx = px < radius ? cx - 1 : cx + 1;
+                const nCol = WORLD_GEN.biomeColors[getBiome(nx + 0.5, cy + 0.5)];
+                tX = Math.pow(1 - distX / radius, falloff) * 0.5;
+                r += ((nCol >> 16) & 0xff) * tX;
+                gcol += ((nCol >> 8) & 0xff) * tX;
+                bcol += (nCol & 0xff) * tX;
+                weight += tX;
             }
+            if (distY < radius) {
+                const ny = py < radius ? cy - 1 : cy + 1;
+                const nCol = WORLD_GEN.biomeColors[getBiome(cx + 0.5, ny + 0.5)];
+                tY = Math.pow(1 - distY / radius, falloff) * 0.5;
+                r += ((nCol >> 16) & 0xff) * tY;
+                gcol += ((nCol >> 8) & 0xff) * tY;
+                bcol += (nCol & 0xff) * tY;
+                weight += tY;
+            }
+            if (tX > 0 && tY > 0) {
+                const nx = px < radius ? cx - 1 : cx + 1;
+                const ny = py < radius ? cy - 1 : cy + 1;
+                const nCol = WORLD_GEN.biomeColors[getBiome(nx + 0.5, ny + 0.5)];
+                const tD = Math.min(tX, tY);
+                r += ((nCol >> 16) & 0xff) * tD;
+                gcol += ((nCol >> 8) & 0xff) * tD;
+                bcol += (nCol & 0xff) * tD;
+                weight += tD;
+            }
+
+            const color = ((r / weight) << 16)
+                | ((gcol / weight) << 8)
+                | (bcol / weight);
             g.fillStyle(color, 1);
             g.fillRect(ix * step, iy * step, step + 1, step + 1);
         }

--- a/test/systems/world_gen/Chunk.test.js
+++ b/test/systems/world_gen/Chunk.test.js
@@ -138,12 +138,15 @@ test('edge samples blend to neighbouring biome colors', () => {
     const fills = scene._graphicsCalls[0].fills;
     const plains = WORLD_GEN.biomeColors[BIOME_IDS.PLAINS];
     const desert = WORLD_GEN.biomeColors[BIOME_IDS.DESERT];
-    const t = 1 - (step / 2) / radius;
-    const expected = lerpColor(
-        plains,
-        desert,
-        Math.pow(t, WORLD_GEN.chunk.blendFalloff) * 0.5,
-    );
+    const t = Math.pow(1 - (step / 2) / radius, WORLD_GEN.chunk.blendFalloff) * 0.5;
+    const wBase = 1;
+    const wDesert = t * 3; // left, top and diagonal neighbours
+    const r = ((plains >> 16) & 0xff) * wBase + ((desert >> 16) & 0xff) * wDesert;
+    const g = ((plains >> 8) & 0xff) * wBase + ((desert >> 8) & 0xff) * wDesert;
+    const b = (plains & 0xff) * wBase + (desert & 0xff) * wDesert;
+    const expected = ((r / (wBase + wDesert)) << 16)
+        | ((g / (wBase + wDesert)) << 8)
+        | (b / (wBase + wDesert));
     assert.equal(fills[0], expected);
     chunk.unload(scene);
     __setNoise2D(origNoise);


### PR DESCRIPTION
## Summary
- smooth biome corner blending so intersecting chunks fade evenly
- adjust chunk blending test to match new weighting

## Technical Approach
- add weighted color accumulation in `drawBiomeTexture`
- update edge blending test for corner weights

## Performance
- runs during chunk load; no per-frame allocations; reuses texture pool

## Risks & Rollback
- blending weights may slightly shift biome colors
- revert commit 08f5e84 if issues arise

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4b9f0aa648322a0558e7d5aa25c57