### PR TITLE
feat: add nightly zombie bonus per day

### DIFF
--- a/systems/world_gen/dayNightSystem.js
+++ b/systems/world_gen/dayNightSystem.js
@@ -95,9 +95,11 @@ export default function createDayNightSystem(scene) {
                 scene.waveNumber++;
                 if (scene.phase !== 'night' || scene.isGameOver) return;
 
+                const dayBonus = scene.dayIndex * nightCfg.perDay;
                 const targetCount = Math.min(
                     nightCfg.baseCount +
-                        (scene.waveNumber - 1) * nightCfg.perWave,
+                        (scene.waveNumber - 1) * nightCfg.perWave +
+                        dayBonus,
                     nightCfg.maxCount,
                 );
 

--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -211,6 +211,7 @@ export const WORLD_GEN = {
         waveIntervalMs: 30_000, // time between waves
         baseCount: 3,           // zombies in wave 1
         perWave: 2,             // +N per subsequent wave
+        perDay: 2,              // +2 zombies added per day
         maxCount: 25,           // clamp
         burstIntervalMs: 200,   // gap between individuals within a wave
       },


### PR DESCRIPTION
## Summary
- add per-day night wave bonus of 2 zombies

## Technical Approach
- compute day-based bonus in `scheduleNightWave` and sum with wave counts
- expose `perDay` in `WORLD_GEN.spawns.zombie.nightWaves`

## Performance
- wave size math done once per wave, no per-frame allocations

## Risks & Rollback
- mis-tuned `perDay` could spike difficulty; revert commit `57091a5` to undo

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4ba1dc76c8322a8de9da6687adea1