### PR TITLE
fix: adjust stump4 collider and keep stump tops visible

### DIFF
--- a/data/resourceDatabase.js
+++ b/data/resourceDatabase.js
@@ -593,7 +593,7 @@ export const RESOURCE_DB = {
     blocking: true,
     trunkDepth: 890,
     leavesDepth: 910,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
   [RESOURCE_IDS.TREE1B]: {
@@ -629,7 +629,7 @@ export const RESOURCE_DB = {
     blocking: true,
     trunkDepth: 890,
     leavesDepth: 910,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
   [RESOURCE_IDS.TREE1C]: {
@@ -665,7 +665,7 @@ export const RESOURCE_DB = {
     blocking: true,
     trunkDepth: 890,
     leavesDepth: 910,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
   [RESOURCE_IDS.TREE2A]: {
@@ -1067,7 +1067,7 @@ export const RESOURCE_DB = {
     collectible: false,
     blocking: true,
     depth: 1,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
   [RESOURCE_IDS.STUMP2]: {
@@ -1086,7 +1086,7 @@ export const RESOURCE_DB = {
     collectible: false,
     blocking: true,
     depth: 1,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
   [RESOURCE_IDS.STUMP3]: {
@@ -1105,7 +1105,7 @@ export const RESOURCE_DB = {
     collectible: false,
     blocking: true,
     depth: 1,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
   [RESOURCE_IDS.STUMP4]: {
@@ -1119,12 +1119,12 @@ export const RESOURCE_DB = {
       textureKey: 'stump4',
       scale: 1.0,
       origin: { x: 0.5, y: 1 },
-      body: { kind: 'circle', radius: 12, offsetX: 0, offsetY: -6, useScale: true, anchor: 'bottomCenter' },
+      body: { kind: 'circle', radius: 28, offsetX: 2, offsetY: -28, useScale: true, anchor: 'bottomCenter' },
     },
     collectible: false,
     blocking: true,
     depth: 1,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
   [RESOURCE_IDS.STUMP5]: {
@@ -1143,7 +1143,7 @@ export const RESOURCE_DB = {
     collectible: false,
     blocking: true,
     depth: 1,
-    tags: ['resource', 'tree'],
+    tags: ['resource', 'tree', 'stump'],
     meta: { rarity: 'common' },
   },
 

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -501,7 +501,7 @@ function createResourceSystem(scene) {
                 }
 
             const leavesCfg = def.world?.leaves;
-            if (leavesCfg) {
+            if (leavesCfg && !(def.tags?.includes('stump'))) {
                 const frameW = trunk.width;
                 const frameH = trunk.height;
 


### PR DESCRIPTION
Summary:
- widen and offset stump4 collider to match sprite
- prevent stumps from fading when player walks behind

Technical Approach:
- update stump entries and tags in `data/resourceDatabase.js`
- skip leaf alpha fade for `stump`-tagged resources in `systems/resourceSystem.js`

Performance:
- uses existing systems; adds only a tag check in update timer

Risks & Rollback:
- collider size may still need tuning; revert commit `f0cb3cc` if issues arise

QA Steps:
- Launch the game
- Find a stump4 and confirm player cannot clip into its top-right corner
- Walk behind any stump and verify top stays fully opaque

------
https://chatgpt.com/codex/tasks/task_e_68c5a990fa608322b78cb46a0cc9f66a