### PR TITLE
chore(resources): consolidate resource registration

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -7,9 +7,7 @@ import { getResourceRegistry } from './world_gen/resources/registry.js';
 import { getBiome } from './world_gen/biomes/biomeMap.js';
 import { getDensity } from './world_gen/noise.js';
 import * as poissonSampler from './world_gen/resources/poissonSampler.js';
-import './world_gen/resources/rocks.js';
-import './world_gen/resources/trees.js';
-import './world_gen/resources/bushes.js';
+import './world_gen/resources/index.js';
 
 const DEFAULT_CLUSTER_GROWTH = 0.3;
 

--- a/systems/world_gen/resources/bushes.js
+++ b/systems/world_gen/resources/bushes.js
@@ -1,4 +1,0 @@
-import { WORLD_GEN } from '../worldGenConfig.js';
-import { registerResourceType } from './registry.js';
-
-registerResourceType('bushes', () => WORLD_GEN?.spawns?.resources?.bushes);

--- a/systems/world_gen/resources/index.js
+++ b/systems/world_gen/resources/index.js
@@ -1,0 +1,7 @@
+// systems/world_gen/resources/index.js
+import { WORLD_GEN } from '../worldGenConfig.js';
+import { registerResourceType } from './registry.js';
+
+registerResourceType('rocks', () => WORLD_GEN?.spawns?.resources?.rocks);
+registerResourceType('trees', () => WORLD_GEN?.spawns?.resources?.trees);
+registerResourceType('bushes', () => WORLD_GEN?.spawns?.resources?.bushes);

--- a/systems/world_gen/resources/rocks.js
+++ b/systems/world_gen/resources/rocks.js
@@ -1,4 +1,0 @@
-import { WORLD_GEN } from '../worldGenConfig.js';
-import { registerResourceType } from './registry.js';
-
-registerResourceType('rocks', () => WORLD_GEN?.spawns?.resources?.rocks);

--- a/systems/world_gen/resources/trees.js
+++ b/systems/world_gen/resources/trees.js
@@ -1,4 +1,0 @@
-import { WORLD_GEN } from '../worldGenConfig.js';
-import { registerResourceType } from './registry.js';
-
-registerResourceType('trees', () => WORLD_GEN?.spawns?.resources?.trees);


### PR DESCRIPTION
## Summary
- consolidate resource registration for rocks, trees, and bushes into a single index module
- update resource system to load new index and remove individual resource modules

## Technical Approach
- add `systems/world_gen/resources/index.js` registering rock, tree, and bush types
- replace individual resource imports in `systems/resourceSystem.js`
- delete legacy `rocks.js`, `trees.js`, and `bushes.js`

## Performance
- no runtime impact; change is organizational only

## Risks & Rollback
- if resources stop spawning, revert commit `01b7106`

## QA Steps
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68c7454e735c8322867b69b91dbba663