### PR TITLE
fix: align tree3 canopy fade heights

### DIFF
--- a/data/resourceDatabase.js
+++ b/data/resourceDatabase.js
@@ -805,7 +805,7 @@ export const RESOURCE_DB = {
       },
       leaves: {
         width: 66,
-        height: 48,
+        height: 29,
         offsetX: 0,
         offsetY: 0,
         useScale: true,
@@ -842,7 +842,7 @@ export const RESOURCE_DB = {
       },
       leaves: {
         width: 89,
-        height: 81,
+        height: 67,
         offsetX: 0,
         offsetY: 0,
         useScale: true,
@@ -879,7 +879,7 @@ export const RESOURCE_DB = {
       },
       leaves: {
         width: 102,
-        height: 90,
+        height: 101,
         offsetX: 0,
         offsetY: 0,
         useScale: true,


### PR DESCRIPTION
Summary:
- align TREE3 canopy fade heights with the top of the trunk collider to silence canopy mismatch warnings.

Technical Approach:
- sampled the source sprite heights for tree3A/B/C and updated `world.leaves.height` in `data/resourceDatabase.js` to match the collider top offset.

Performance:
- data-only change; no per-frame allocations or runtime impact.

Risks & Rollback:
- incorrect canopy heights could reintroduce fade alignment issues; revert this commit to restore prior values.

QA Steps:
- npm test
- In a local build, spawn each TREE3 variant and confirm canopy fading begins exactly at the trunk hitbox top.

------
https://chatgpt.com/codex/tasks/task_e_68c885dff7888322aec9a57f47d78fcb