### PR TITLE
feat: unify escape key menu closing

### DIFF
--- a/systems/inputSystem.js
+++ b/systems/inputSystem.js
@@ -130,6 +130,7 @@ export default function createInputSystem(scene) {
     // ----- Pause & Auto-Pause -----
     function onEsc() {
         if (scene.isGameOver) return;
+        if (scene.uiScene?.handleEscape?.()) return;
         if (!scene.scene.isActive('PauseScene')) {
             scene.scene.launch('PauseScene');
             scene.scene.pause();

--- a/systems/uiEscapeManager.js
+++ b/systems/uiEscapeManager.js
@@ -1,0 +1,71 @@
+// systems/uiEscapeManager.js
+// Tracks UI menus/panels that should respond to the Escape key.
+// Maintains a stack of open menus so the most recently opened closes first.
+
+export default class UIEscapeManager {
+    constructor() {
+        this._registry = new Map(); // id -> { close: fn, isOpen: bool }
+        this._stack = []; // ordered list of open ids (oldest -> newest)
+    }
+
+    register(id, closeFn) {
+        if (!id || typeof closeFn !== 'function') return;
+        const entry = this._registry.get(id) || {};
+        entry.close = closeFn;
+        entry.isOpen = !!entry.isOpen;
+        this._registry.set(id, entry);
+    }
+
+    unregister(id) {
+        if (!id) return;
+        this._registry.delete(id);
+        const idx = this._stack.indexOf(id);
+        if (idx >= 0) this._stack.splice(idx, 1);
+    }
+
+    setOpen(id, isOpen) {
+        if (!id) return;
+        const entry = this._registry.get(id);
+        if (!entry) return;
+
+        entry.isOpen = !!isOpen;
+        const idx = this._stack.indexOf(id);
+        if (entry.isOpen) {
+            if (idx >= 0) this._stack.splice(idx, 1);
+            this._stack.push(id);
+        } else if (idx >= 0) {
+            this._stack.splice(idx, 1);
+        }
+    }
+
+    handleEscape() {
+        for (let i = this._stack.length - 1; i >= 0; i--) {
+            const id = this._stack[i];
+            const entry = this._registry.get(id);
+            if (!entry) {
+                this._stack.splice(i, 1);
+                continue;
+            }
+            if (!entry.isOpen) {
+                this._stack.splice(i, 1);
+                continue;
+            }
+            if (typeof entry.close === 'function') {
+                entry.close();
+                return true;
+            }
+            return false;
+        }
+
+        for (const [id, entry] of this._registry.entries()) {
+            if (entry.isOpen && typeof entry.close === 'function') {
+                entry.close();
+                const idx = this._stack.indexOf(id);
+                if (idx >= 0) this._stack.splice(idx, 1);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Summary:
- Centralize Escape-key handling so UI panels close before the pause menu opens, keeping controls consistent.
- Provide a reusable escape stack that future menus (inventory, chests, crafting) can register with.

Technical Approach:
- Added `systems/uiEscapeManager.js` to manage a stack of closable UI layers.
- Updated `scenes/UIScene.js` to register the inventory panel, expose `closeInventory`, and forward Escape handling through the manager.
- Taught `systems/inputSystem.js` to ask the UI scene to consume Escape presses before launching `PauseScene`.

Performance:
- Escape stack only updates on open/close events and key presses; no per-frame allocations or extra work in `update()`.
- Reuses existing inventory cleanup helpers without introducing new per-frame math.

Risks & Rollback:
- Menus that forget to register or update their open state will not auto-close with Escape; reverting the commit restores the prior behavior.
- Rollback by reverting commit `ee42a5b` if Escape interactions regress.

QA Steps:
- npm test
- Launch the game, open the inventory (TAB), and press Escape to close it.
- With no panels open, press Escape to open the pause menu; press Escape again to resume.


------
https://chatgpt.com/codex/tasks/task_e_68cdcf8f88008322a830c1c6b3780967