### PR TITLE
Fix pooled resource cleanup to avoid dangling overlays

### DIFF
--- a/systems/pools/resourcePool.js
+++ b/systems/pools/resourcePool.js
@@ -1,6 +1,44 @@
 // systems/pools/resourcePool.js
 // Object pool for world resources (trees, rocks, bushes).
 
+export function cleanupResourceLayers(obj) {
+    if (!obj || typeof obj.getData !== 'function') return;
+
+    const canSetData = typeof obj.setData === 'function';
+
+    const overlayCleanup = obj.getData('overlayCleanup');
+    if (typeof overlayCleanup === 'function') {
+        if (typeof obj.off === 'function') {
+            obj.off('destroy', overlayCleanup);
+        }
+        if (canSetData) obj.setData('overlayCleanup', null);
+        overlayCleanup();
+    } else {
+        const overlay = obj.getData('overlaySprite');
+        if (
+            overlay &&
+            typeof overlay.destroy === 'function' &&
+            (overlay.scene || overlay.active !== false)
+        ) {
+            overlay.destroy();
+        }
+    }
+    if (canSetData) obj.setData('overlaySprite', null);
+
+    const topDestroy = obj.getData('topSpriteDestroy');
+    if (typeof topDestroy === 'function' && typeof obj.off === 'function') {
+        obj.off('destroy', topDestroy);
+    }
+    const top = obj.getData('topSprite');
+    if (top && typeof top.destroy === 'function' && (top.scene || top.active !== false)) {
+        top.destroy();
+    }
+    if (canSetData) {
+        obj.setData('topSprite', null);
+        obj.setData('topSpriteDestroy', null);
+    }
+}
+
 export default function createResourcePool(scene) {
     const pool = [];
 
@@ -21,42 +59,44 @@ export default function createResourcePool(scene) {
 
     function release(obj) {
         if (!obj) return;
-        const chunk = obj.getData('chunk');
-        if (chunk && chunk.group) {
+        const chunk = typeof obj.getData === 'function' ? obj.getData('chunk') : null;
+        if (chunk && chunk.group && typeof chunk.group.remove === 'function') {
             chunk.group.remove(obj, false);
         }
-        // If this is a non-physics decor object, just destroy it
-        if (!obj.body) {
-            try { obj.destroy(); } catch {}
-            return;
-        }
-        // If this is a static physics body (StaticGroup), don't pool; destroy
-        if (obj.body && obj.body.moves === false) {
-            try { obj.destroy(); } catch {}
-            return;
-        }
-        scene.resources.remove(obj, false);
-        obj.body && obj.body.stop && obj.body.stop();
-        if (obj.body) obj.body.enable = false;
-        const top = obj.getData('topSprite');
-        if (top && top.destroy) top.destroy();
-        const overlayCleanup = obj.getData('overlayCleanup');
-        if (typeof overlayCleanup === 'function') {
-            try { overlayCleanup(); } catch {}
-        } else {
-            const overlay = obj.getData('overlaySprite');
-            if (overlay && overlay.destroy) {
-                try { overlay.destroy(); } catch {}
+        cleanupResourceLayers(obj);
+        const body = obj.body || null;
+        const hasScene = !!obj.scene;
+        const isActive = obj.active !== false;
+        const shouldDestroy = !body || body.moves === false;
+        if (shouldDestroy) {
+            if (hasScene && isActive && typeof obj.destroy === 'function') {
+                obj.destroy();
             }
+            return;
         }
-        obj.removeFromDisplayList();
-        obj.setActive(false).setVisible(false);
-        obj.setData('chunk', null);
-        obj.setData('chunkIdx', null);
-        obj.setData('topSprite', null);
-        obj.setData('overlaySprite', null);
-        obj.setData('overlayCleanup', null);
-        pool.push(obj);
+        if (scene.resources && typeof scene.resources.remove === 'function') {
+            scene.resources.remove(obj, false);
+        }
+        if (body && body.enable !== false && typeof body.stop === 'function') {
+            body.stop();
+        }
+        if (body) body.enable = false;
+        if (typeof obj.removeFromDisplayList === 'function') {
+            obj.removeFromDisplayList();
+        }
+        if (typeof obj.setActive === 'function') obj.setActive(false);
+        else obj.active = false;
+        if (typeof obj.setVisible === 'function') obj.setVisible(false);
+        else obj.visible = false;
+        if (typeof obj.setData === 'function') {
+            obj.setData('chunk', null);
+            obj.setData('chunkIdx', null);
+            obj.setData('overlayCleanup', null);
+            obj.setData('overlaySprite', null);
+            obj.setData('topSprite', null);
+            obj.setData('topSpriteDestroy', null);
+        }
+        if (!pool.includes(obj)) pool.push(obj);
     }
 
     function size() {

--- a/test/systems/resourcePool.test.js
+++ b/test/systems/resourcePool.test.js
@@ -1,0 +1,188 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import createResourcePool from '../../systems/pools/resourcePool.js';
+
+function createLayer(name) {
+    return {
+        name,
+        active: true,
+        scene: {},
+        destroyed: false,
+        destroy() {
+            this.destroyed = true;
+            this.active = false;
+            this.scene = null;
+        },
+    };
+}
+
+function createTrunk({ body = null, scene } = {}) {
+    const data = new Map();
+    const events = new Map();
+    if (body && typeof body.enable === 'undefined') {
+        body.enable = true;
+    }
+    return {
+        active: true,
+        visible: true,
+        scene: scene || {},
+        body,
+        destroyCount: 0,
+        removed: false,
+        getData(key) {
+            return data.get(key);
+        },
+        setData(key, value) {
+            data.set(key, value);
+            return this;
+        },
+        setActive(value) {
+            this.active = value;
+            return this;
+        },
+        setVisible(value) {
+            this.visible = value;
+            return this;
+        },
+        setTexture() {
+            return this;
+        },
+        setOrigin() {
+            return this;
+        },
+        setScale() {
+            return this;
+        },
+        setDepth() {
+            return this;
+        },
+        setPosition() {
+            return this;
+        },
+        removeFromDisplayList() {
+            this.removed = true;
+            return this;
+        },
+        once(event, cb) {
+            events.set(event, cb);
+            return this;
+        },
+        off(event, cb) {
+            const stored = events.get(event);
+            if (stored === cb) {
+                events.delete(event);
+            }
+            return this;
+        },
+        destroy() {
+            this.destroyCount += 1;
+            this.scene = null;
+            this.active = false;
+            this.visible = false;
+            return this;
+        },
+    };
+}
+
+function attachVisuals(trunk) {
+    const overlaySprite = createLayer('overlay');
+    const topSprite = createLayer('top');
+    const cleanup = () => {
+        overlaySprite.destroy();
+    };
+    const destroyTop = () => {
+        topSprite.destroy();
+    };
+    trunk.setData('overlaySprite', overlaySprite);
+    trunk.setData('overlayCleanup', cleanup);
+    trunk.once('destroy', cleanup);
+    trunk.setData('topSprite', topSprite);
+    trunk.setData('topSpriteDestroy', destroyTop);
+    trunk.once('destroy', destroyTop);
+    return { overlaySprite, topSprite };
+}
+
+function createScene() {
+    const addCalls = [];
+    const removeCalls = [];
+    return {
+        resources: {
+            add(obj) {
+                addCalls.push(obj);
+            },
+            remove(obj, disable) {
+                removeCalls.push({ obj, disable });
+            },
+            create() {
+                throw new Error('not expected in test');
+            },
+        },
+        _adds: addCalls,
+        _removes: removeCalls,
+    };
+}
+
+test('resource pool release cleans up resources deterministically', () => {
+    const scene = createScene();
+    const pool = createResourcePool(scene);
+
+    const decor = createTrunk({ scene });
+    attachVisuals(decor);
+    const decorChunkGroup = {
+        calls: 0,
+        remove(obj, reset) {
+            this.calls += 1;
+            this.last = { obj, reset };
+        },
+    };
+    decor.setData('chunk', { group: decorChunkGroup });
+
+    assert.equal(pool.size(), 0);
+    pool.release(decor);
+    assert.equal(pool.size(), 0);
+    assert.equal(decor.destroyCount, 1);
+    assert.equal(decorChunkGroup.calls, 1);
+    assert.equal(decor.getData('overlaySprite'), null);
+    assert.equal(decor.getData('topSprite'), null);
+
+    pool.release(decor);
+    assert.equal(pool.size(), 0);
+    assert.equal(decor.destroyCount, 1);
+
+    const staticBody = { moves: false, enable: true };
+    const staticObj = createTrunk({ scene, body: staticBody });
+    attachVisuals(staticObj);
+    pool.release(staticObj);
+    assert.equal(pool.size(), 0);
+    assert.equal(staticObj.destroyCount, 1);
+
+    const dynamicBody = {
+        moves: true,
+        enable: true,
+        stopCalled: 0,
+        stop() {
+            this.stopCalled += 1;
+        },
+    };
+    const dynamicObj = createTrunk({ scene, body: dynamicBody });
+    attachVisuals(dynamicObj);
+    dynamicObj.setData('chunk', { group: { remove() {} } });
+
+    pool.release(dynamicObj);
+    assert.equal(pool.size(), 1);
+    assert.equal(dynamicObj.destroyCount, 0);
+    assert.equal(dynamicBody.stopCalled, 1);
+    assert.equal(dynamicObj.active, false);
+
+    pool.release(dynamicObj);
+    assert.equal(pool.size(), 1);
+    assert.equal(dynamicBody.stopCalled, 1);
+
+    const reused = pool.acquire('tex');
+    assert.strictEqual(reused, dynamicObj);
+    assert.equal(pool.size(), 0);
+    assert.equal(dynamicObj.active, true);
+    assert.equal(scene._adds.length, 1);
+    assert.ok(scene._removes.length >= 1);
+});


### PR DESCRIPTION
## Summary
- normalize resource pool release so layered sprites and physics state are cleaned deterministically
- update harvest logic to detach overlay/top sprites before destroying or pooling resources
- add coverage ensuring decor/static releases do not grow the pool and repeated releases stay idempotent

## Technical Approach
- systems/pools/resourcePool.js: add shared cleanup routine for overlays/top sprites and guard repeated release logic, including physics body teardown checks
- systems/resourceSystem.js: retain destroy callbacks for top sprites and invoke the shared cleanup before destroy/release paths
- test/systems/resourcePool.test.js: exercise decor, static, and dynamic releases to verify pool sizing and cleanup expectations

## Performance
- cleanup helper only runs during resource harvest/release, avoiding new per-frame allocations and reusing pooled sprites
- guard body.stop() to prevent redundant calls when objects are already disabled

## Risks & Rollback
- Cleanup ordering changes could affect resource visuals if destroy listeners depend on previous sequencing; rollback by restoring prior release logic if regressions appear

## QA Steps
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cdd589ddb08322a20b86dff72e8863