### PR TITLE
Fix resource pooling release guards

### DIFF
--- a/systems/DevTools.js
+++ b/systems/DevTools.js
@@ -38,6 +38,15 @@ const DevTools = {
     },
 
     _appliedTimeScale: 1,
+    _resourcePoolDebug: false,
+
+    setResourcePoolDebug(value = false) {
+        this._resourcePoolDebug = !!value;
+    },
+
+    shouldLogResourcePool() {
+        return !!this._resourcePoolDebug;
+    },
 
     // ─────────────────────────────────────────────────────────────
     // RENDER CONFIG

--- a/systems/pools/resourcePool.js
+++ b/systems/pools/resourcePool.js
@@ -1,6 +1,35 @@
 // systems/pools/resourcePool.js
 // Object pool for world resources (trees, rocks, bushes).
 
+import DevTools from '../DevTools.js';
+
+function shouldLogResourceDebug() {
+    return (
+        !!DevTools &&
+        typeof DevTools.shouldLogResourcePool === 'function' &&
+        DevTools.shouldLogResourcePool()
+    );
+}
+
+function logResourceDebug(message, obj) {
+    if (!shouldLogResourceDebug()) return;
+    console.warn(`[ResourcePool] ${message}`, obj);
+}
+
+function isGameObjectDestroyed(obj) {
+    return !!obj && obj.active === false && !obj.scene;
+}
+
+export function safeDestroyResourceSprite(obj, label = 'resource sprite') {
+    if (!obj || typeof obj.destroy !== 'function') return false;
+    if (isGameObjectDestroyed(obj)) {
+        logResourceDebug(`${label} was already destroyed`, obj);
+        return false;
+    }
+    obj.destroy();
+    return true;
+}
+
 export function cleanupResourceLayers(obj) {
     if (!obj || typeof obj.getData !== 'function') return;
 
@@ -15,12 +44,8 @@ export function cleanupResourceLayers(obj) {
         overlayCleanup();
     } else {
         const overlay = obj.getData('overlaySprite');
-        if (
-            overlay &&
-            typeof overlay.destroy === 'function' &&
-            (overlay.scene || overlay.active !== false)
-        ) {
-            overlay.destroy();
+        if (overlay && typeof overlay.destroy === 'function') {
+            safeDestroyResourceSprite(overlay, 'resource overlay');
         }
     }
     if (canSetData) obj.setData('overlaySprite', null);
@@ -30,8 +55,8 @@ export function cleanupResourceLayers(obj) {
         obj.off('destroy', topDestroy);
     }
     const top = obj.getData('topSprite');
-    if (top && typeof top.destroy === 'function' && (top.scene || top.active !== false)) {
-        top.destroy();
+    if (top && typeof top.destroy === 'function') {
+        safeDestroyResourceSprite(top, 'resource top sprite');
     }
     if (canSetData) {
         obj.setData('topSprite', null);
@@ -41,6 +66,50 @@ export function cleanupResourceLayers(obj) {
 
 export default function createResourcePool(scene) {
     const pool = [];
+
+    function destroyStaticResource(obj) {
+        if (!obj) return;
+
+        if (scene.resources && typeof scene.resources.remove === 'function') {
+            scene.resources.remove(obj, false);
+        }
+
+        const body = obj.body || null;
+        if (body) {
+            if (body.enable !== false && typeof body.stop === 'function') {
+                body.stop();
+            }
+            body.enable = false;
+        }
+
+        let overlay = null;
+        let overlayCleanup = null;
+        let top = null;
+        if (typeof obj.getData === 'function') {
+            overlay = obj.getData('overlaySprite');
+            overlayCleanup = obj.getData('overlayCleanup');
+            top = obj.getData('topSprite');
+        }
+
+        if (typeof obj.setData === 'function') {
+            obj.setData('chunk', null);
+            obj.setData('chunkIdx', null);
+            obj.setData('overlayCleanup', null);
+            obj.setData('overlaySprite', null);
+            obj.setData('topSprite', null);
+            obj.setData('topSpriteDestroy', null);
+        }
+
+        if (shouldLogResourceDebug() && (overlay || overlayCleanup || top)) {
+            logResourceDebug('destroyStaticResource() found lingering overlays', {
+                overlay,
+                overlayCleanup,
+                top,
+            });
+        }
+
+        safeDestroyResourceSprite(obj, 'resource sprite');
+    }
 
     function acquire(texKey) {
         const obj = pool.pop();
@@ -63,16 +132,28 @@ export default function createResourcePool(scene) {
         if (chunk && chunk.group && typeof chunk.group.remove === 'function') {
             chunk.group.remove(obj, false);
         }
+        if (isGameObjectDestroyed(obj)) {
+            logResourceDebug('release() received a destroyed sprite', obj);
+            return;
+        }
         cleanupResourceLayers(obj);
         const body = obj.body || null;
-        const hasScene = !!obj.scene;
-        const isActive = obj.active !== false;
         const shouldDestroy = !body || body.moves === false;
         if (shouldDestroy) {
-            if (hasScene && isActive && typeof obj.destroy === 'function') {
-                obj.destroy();
-            }
+            destroyStaticResource(obj);
             return;
+        }
+        if (typeof obj.getData === 'function') {
+            const overlay = obj.getData('overlaySprite');
+            const overlayCleanup = obj.getData('overlayCleanup');
+            const top = obj.getData('topSprite');
+            if (shouldLogResourceDebug() && (overlay || overlayCleanup || top)) {
+                logResourceDebug('release() pooling sprite with lingering overlays', {
+                    overlay,
+                    overlayCleanup,
+                    top,
+                });
+            }
         }
         if (scene.resources && typeof scene.resources.remove === 'function') {
             scene.resources.remove(obj, false);

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -8,7 +8,7 @@ import { getBiome } from './world_gen/biomes/biomeMap.js';
 import { getDensity } from './world_gen/noise.js';
 import * as poissonSampler from './world_gen/resources/poissonSampler.js';
 import './world_gen/resources/index.js';
-import { cleanupResourceLayers } from './pools/resourcePool.js';
+import { cleanupResourceLayers, safeDestroyResourceSprite } from './pools/resourcePool.js';
 
 const DEFAULT_CLUSTER_GROWTH = 0.3;
 
@@ -386,7 +386,7 @@ function createLayeredResource(scene, def, x, y) {
     }
 
     const cleanup = () => {
-        try { overlaySprite.destroy(); } catch {}
+        safeDestroyResourceSprite(overlaySprite, 'resource overlay');
         const arr = scene._treeLeaves;
         if (arr) {
             const idx = arr.indexOf(data);
@@ -803,6 +803,12 @@ function createResourceSystem(scene) {
                     }
                     if (onHarvest) onHarvest(trunk, id, x, y);
                     cleanupResourceLayers(trunk);
+                    if (typeof trunk.setData === 'function') {
+                        trunk.setData('overlayCleanup', null);
+                        trunk.setData('overlaySprite', null);
+                        trunk.setData('topSprite', null);
+                        trunk.setData('topSpriteDestroy', null);
+                    }
                     if (needsPhysics) {
                         if (trunk.scene && typeof trunk.destroy === 'function') {
                             trunk.destroy();


### PR DESCRIPTION
Summary:
- Hardened resource pool release/destroy paths so reused sprites never double-destroy and upstream misuse is surfaced via DevTools-gated warnings.

Technical Approach:
- systems/pools/resourcePool.js: added a safeDestroyResourceSprite helper, split static destroy logic, and gated debug logging through DevTools.shouldLogResourcePool().
- systems/resourceSystem.js: cleared overlay/top sprite references before recycling and reused the shared helper for overlay cleanup callbacks.
- systems/DevTools.js: exposed a setResourcePoolDebug toggle consumed by the pool for opt-in diagnostics.

Performance:
- All changes execute on release/harvest events; no per-frame allocations or additional update() math were introduced and pooling for movable bodies is unchanged.

Risks & Rollback:
- Potential diagnostic log spam if resource cleanup misbehaves while DevTools logging is enabled; revert commit fix(resources): guard pooled release to restore previous behavior.

QA Steps:
- `npm test`
- In the browser console, run `DevTools.setResourcePoolDebug(true)` and harvest a resource to verify no warnings unless a double-release is forced.
- Harvest layered resources (trees/rocks with overlays) and confirm overlays/top sprites disappear without console errors.


------
https://chatgpt.com/codex/tasks/task_e_68cdd8cea74883229289987396f05d9b