### PR TITLE
Fix chunk job cleanup races

### DIFF
--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -9,6 +9,7 @@ import { getDensity } from './world_gen/noise.js';
 import * as poissonSampler from './world_gen/resources/poissonSampler.js';
 import './world_gen/resources/index.js';
 import { cleanupResourceLayers } from './pools/resourcePool.js';
+import DevTools from './DevTools.js';
 
 const DEFAULT_CLUSTER_GROWTH = 0.3;
 
@@ -450,6 +451,11 @@ export function pickClusterCount(min, max, rng = Math.random, growthChance = DEF
 function createResourceSystem(scene) {
     // Background job timers for time-sliced chunk population
     const _chunkJobs = new Map(); // key: "cx,cy" -> Phaser.TimerEvent
+
+    function _isTimerDone(timer) {
+        if (!timer) return true;
+        return !!(timer.removed || timer.pendingDelete || timer.hasDispatched);
+    }
     // Ensure resource collision/overlap systems are set up once
     function ensureColliders() {
         if (!scene.player || !scene.physics) return;
@@ -537,14 +543,82 @@ function createResourceSystem(scene) {
 
     function _cancelChunkJob(chunk) {
         const key = _keyForChunk(chunk);
-        const t = _chunkJobs.get(key);
-        if (t) {
-            try { t.remove(false); } catch {}
-            _chunkJobs.delete(key);
+        const timer = _chunkJobs.get(key);
+        if (!timer) return;
+
+        _chunkJobs.delete(key);
+
+        const removed = timer?.removed === true;
+        const dispatched = timer?.hasDispatched === true;
+        const pendingDelete = timer?.pendingDelete === true;
+
+        if (removed || dispatched) {
+            if (DevTools?.cheats?.chunkDetails) {
+                const state = {
+                    key,
+                    removed,
+                    hasDispatched: dispatched,
+                    pendingDelete,
+                };
+                console.warn('[resourceSystem] cancelChunkJob after completion', state);
+                console.assert(
+                    !dispatched && !removed,
+                    `[resourceSystem] cancelChunkJob called after completion for ${key}`,
+                    state,
+                );
+            }
+            return;
+        }
+
+        if (pendingDelete) return;
+
+        if (typeof timer.remove === 'function') {
+            timer.remove(false);
         }
     }
 
     function spawnChunkResources(chunk) {
+        if (!chunk) return null;
+
+        const key = _keyForChunk(chunk);
+        const existing = _chunkJobs.get(key);
+        const existingDone = existing ? _isTimerDone(existing) : false;
+
+        if (existing && !existingDone) {
+            return existing;
+        }
+        if (existingDone) {
+            _chunkJobs.delete(key);
+        }
+
+        if (!scene?.time?.addEvent || typeof scene.time.addEvent !== 'function') {
+            _chunkJobs.delete(key);
+            return _populateChunkResources(chunk);
+        }
+
+        const job = scene.time.addEvent({
+            delay: 0,
+            callback: () => {
+                try {
+                    _populateChunkResources(chunk);
+                } finally {
+                    if (_chunkJobs.get(key) === job) {
+                        _chunkJobs.delete(key);
+                    }
+                }
+            },
+        });
+
+        if (!job || typeof job.remove !== 'function') {
+            _chunkJobs.delete(key);
+            return _populateChunkResources(chunk);
+        }
+
+        _chunkJobs.set(key, job);
+        return job;
+    }
+
+    function _populateChunkResources(chunk) {
         // Make sure physics interactions exist before creating any resources
         ensureColliders();
         const registry = getResourceRegistry();


### PR DESCRIPTION
Summary:
- Ensure chunk job timers are removed safely by deleting map entries first and checking timer state before removal.
- Clear chunk job map entries when timers complete and add DevTools-gated logging for finished-job cancellations to surface races.

Technical Approach:
- systems/resourceSystem.js: Adjust _cancelChunkJob to inspect Phaser.TimerEvent flags, add scheduling wrapper for spawnChunkResources that registers completion cleanup, and gate debug logging behind DevTools.cheats.chunkDetails.

Performance:
- Chunk work still runs on Phaser timers; no per-frame allocations were added and scheduling remains time-sliced.

Risks & Rollback:
- Minimal risk of timers not firing if Phaser APIs change; revert by restoring systems/resourceSystem.js to prior revision.

QA Steps:
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cdd8ce2e9083229d7fb59710be21de