### PR TITLE
Add day/night segment tracking and config

### DIFF
--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -62,6 +62,15 @@ export const WORLD_GEN = {
     nightMs: 120_000,        // 2 min night
     transitionMs: 15_000,    // 15s fade before/after night
     nightOverlayAlpha: 0.55, // darkness amount at deepest night (0..1)
+    segments: {
+        perPhase: 3, // day/night are broken into thirds for pacing cues
+        day: {
+            labels: ['Morning', 'Afternoon', 'Evening'],
+        },
+        night: {
+            labels: ['Nightfall', 'Midnight', 'Late Night'],
+        },
+    },
     // (You can tweak these freely without touching scene code.)
   },
 


### PR DESCRIPTION
Summary:
* Centralized the day/night segment counts and labels in `worldGenConfig` so the cycle pacing can be tuned in one place.
* Extended `dayNightSystem` with reusable segment arrays, cached segment state, and a `getSegmentLabel()` helper while keeping tick allocations flat.

Technical Approach:
* Added a `segments` section to `systems/world_gen/worldGenConfig.js` that defines per-phase segment counts and labels.
* Updated `systems/world_gen/dayNightSystem.js` to export `DAY_SEGMENTS`/`NIGHT_SEGMENTS`, cache the active segment index/label, reset on phase transitions, and refresh segment state in `tick()`.

Performance:
* Segment arrays are defined once and reused; tick math only touches numbers/strings and avoids per-frame object creation.

Risks & Rollback:
* Regression risk is limited to day/night transitions; reverting the two touched files returns to the prior behavior.

QA Steps:
* `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cdd89a69fc8322a01554401f5ab68b