### PR TITLE
feat: refresh time HUD segment labeling

### DIFF
--- a/scenes/UIScene.js
+++ b/scenes/UIScene.js
@@ -423,6 +423,24 @@ export default class UIScene extends Phaser.Scene {
         this.timeBarFill = this.add.rectangle(this.cameras.main.centerX - barW / 2, 30, 0, barH, 0xffff66)
             .setOrigin(0, 0.5).setAlpha(0.9);
 
+        const barStartX = this.cameras.main.centerX - barW / 2;
+        const markerWidth = 2;
+        const markerHeight = barH + 2;
+        const markerAlpha = 0.35;
+        const firstMarkerX = barStartX + barW / 3;
+        const secondMarkerX = barStartX + (2 * barW) / 3;
+
+        this.timeBarMarkers = [
+            this.add
+                .rectangle(firstMarkerX, 30, markerWidth, markerHeight, 0xffffff)
+                .setOrigin(0.5, 0.5)
+                .setAlpha(markerAlpha),
+            this.add
+                .rectangle(secondMarkerX, 30, markerWidth, markerHeight, 0xffffff)
+                .setOrigin(0.5, 0.5)
+                .setAlpha(markerAlpha),
+        ];
+
         // Initial paint (panel may start hidden, but we prep visuals)
         this.#refreshAllIcons();
         this.#queueBottomHotbarRefresh();
@@ -1029,13 +1047,13 @@ export default class UIScene extends Phaser.Scene {
     // -------------------------
     // Day/Night HUD update (called by MainScene)
     // -------------------------
-    updateTimeDisplay(dayIndex, phaseLabel, progress) {
+    updateTimeDisplay(dayIndex, segmentLabel, progress) {
         // skip if elements were destroyed (e.g., during scene restart)
         if (!this.dayNightLabel?.active || !this.timeBarFill?.active || !this.timeBarBg?.active) return;
-        this.dayNightLabel.setText(`Day ${dayIndex} — ${phaseLabel}`);
+        const label = segmentLabel || 'Daytime';
+        this.dayNightLabel.setText(`Day ${dayIndex} — ${label}`);
         const barW = this.timeBarBg.width;
         const clamped = Phaser.Math.Clamp(progress, 0, 1);
         this.timeBarFill.width = Math.max(0, barW * clamped);
-        this.timeBarFill.setFillStyle(phaseLabel === 'Night' ? 0x66aaff : 0xffff66);
     }
 }

--- a/systems/world_gen/dayNightSystem.js
+++ b/systems/world_gen/dayNightSystem.js
@@ -14,10 +14,10 @@ export const DAY_SEGMENTS =
 export const NIGHT_SEGMENTS =
     Array.isArray(SEGMENT_CONFIG.night?.labels) && SEGMENT_CONFIG.night.labels.length > 0
         ? SEGMENT_CONFIG.night.labels
-        : ['Night', 'Night', 'Night'];
+        : ['Dusk', 'Midnight', 'Dawn'];
 
 const DEFAULT_DAY_SEGMENT_LABEL = DAY_SEGMENTS[0] || 'Daytime';
-const DEFAULT_NIGHT_SEGMENT_LABEL = NIGHT_SEGMENTS[0] || 'Night';
+const DEFAULT_NIGHT_SEGMENT_LABEL = NIGHT_SEGMENTS[0] || 'Dusk';
 const MAX_DAY_SEGMENT_INDEX = Math.max(0, Math.min(DAY_SEGMENTS.length - 1, SEGMENT_COUNT - 1));
 const MAX_NIGHT_SEGMENT_INDEX = Math.max(
     0,
@@ -241,8 +241,12 @@ export default function createDayNightSystem(scene) {
         const elapsed = getPhaseElapsed();
         const duration = getPhaseDuration();
         const progress = Phaser.Math.Clamp(elapsed / duration, 0, 1);
-        const phaseLabel = scene.phase === 'day' ? 'Daytime' : 'Night';
-        scene.uiScene.updateTimeDisplay(scene.dayIndex, phaseLabel, progress);
+        const segmentLabel = getSegmentLabel();
+        scene.uiScene.updateTimeDisplay(scene.dayIndex, segmentLabel, progress);
+        const fill = scene.uiScene.timeBarFill;
+        if (fill?.setFillStyle) {
+            fill.setFillStyle(scene.phase === 'night' ? 0x66aaff : 0xffff66);
+        }
     }
 
     // ----- Tick -----

--- a/systems/world_gen/worldGenConfig.js
+++ b/systems/world_gen/worldGenConfig.js
@@ -68,7 +68,7 @@ export const WORLD_GEN = {
             labels: ['Morning', 'Afternoon', 'Evening'],
         },
         night: {
-            labels: ['Nightfall', 'Midnight', 'Late Night'],
+            labels: ['Dusk', 'Midnight', 'Dawn'],
         },
     },
     // (You can tweak these freely without touching scene code.)


### PR DESCRIPTION
## Summary
- show the active day/night segment in the HUD label and highlight thirds of the timeline for quick scanning.
- default night segment labels now read Dusk, Midnight, and Dawn to match requested naming.
- configure the world-gen night segment labels to Dusk, Midnight, and Dawn so the HUD reflects the requested wording with default data.

## Technical Approach
- updated `scenes/UIScene.js` to add persistent marker sprites on the time bar and retitle the label with the supplied segment text.
- updated `systems/world_gen/dayNightSystem.js` to pass `getSegmentLabel()` into the UI update and recolor the bar fill by phase.
- updated `systems/world_gen/dayNightSystem.js` to default night segment labels to Dusk, Midnight, and Dawn when config is absent.
- updated `systems/world_gen/worldGenConfig.js` to rename the configured night segment labels to Dusk, Midnight, and Dawn.

## Performance
- all new markers are created once during HUD construction; runtime updates reuse existing objects and avoid allocations inside the per-frame tick.

## Risks & Rollback
- low risk: HUD rendering only. Revert by restoring `scenes/UIScene.js`, `systems/world_gen/dayNightSystem.js`, and `systems/world_gen/worldGenConfig.js` to their previous revisions.

## QA Steps
- Launch the game and let the day/night cycle advance.
- Confirm the HUD label reflects segment names (e.g., Dusk, Midnight, Dawn).
- Observe the time bar fill shifts between yellow (day) and blue (night) and that stationary markers appear at one-third intervals.


------
https://chatgpt.com/codex/tasks/task_e_68cdde1a3c648322ad92e67c5fd5d086