### PR TITLE
fix: prevent night wave timer leaks

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -24,7 +24,6 @@ export default class MainScene extends Phaser.Scene {
         this.phaseStartTime = 0; // ms since scene start
         this.waveNumber = 0; // increments each night
         this.spawnZombieTimer = null; // day trickle timer
-        this.nightWaveTimer = null; // night waves timer
 
         // Charge state (generic to any charge-capable weapon)
         this.isCharging = false;

--- a/systems/world_gen/dayNightSystem.js
+++ b/systems/world_gen/dayNightSystem.js
@@ -24,6 +24,18 @@ const MAX_NIGHT_SEGMENT_INDEX = Math.max(
     Math.min(NIGHT_SEGMENTS.length - 1, SEGMENT_COUNT - 1),
 );
 
+let nightWaveTimers = [];
+
+function clearNightWaveTimers() {
+    for (let i = 0; i < nightWaveTimers.length; i++) {
+        const timer = nightWaveTimers[i];
+        if (timer?.remove) {
+            timer.remove(false);
+        }
+    }
+    nightWaveTimers = [];
+}
+
 export default function createDayNightSystem(scene) {
     let cachedSegmentPhase = 'day';
     let cachedSegmentIndex = 0;
@@ -31,6 +43,8 @@ export default function createDayNightSystem(scene) {
 
     scene.phaseSegmentIndex = cachedSegmentIndex;
     scene.phaseSegmentLabel = cachedSegmentLabel;
+
+    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, clearNightWaveTimers);
 
     function resetSegmentForPhase(phase) {
         const isNight = phase === 'night';
@@ -85,14 +99,11 @@ export default function createDayNightSystem(scene) {
         scene.phase = 'day';
         scene.phaseStartTime = DevTools.now(scene);
         scene._phaseElapsedMs = 0;
-        if (scene.nightWaveTimer) {
-            scene.nightWaveTimer.remove(false);
-            scene.nightWaveTimer = null;
-        }
         if (scene.spawnZombieTimer) {
             scene.spawnZombieTimer.remove(false);
             scene.spawnZombieTimer = null;
         }
+        clearNightWaveTimers();
         scene.waveNumber = 0;
         resetSegmentForPhase('day');
         scheduleDaySpawn();
@@ -107,6 +118,7 @@ export default function createDayNightSystem(scene) {
             scene.spawnZombieTimer.remove(false);
             scene.spawnZombieTimer = null;
         }
+        clearNightWaveTimers();
         scene.waveNumber = 0;
         resetSegmentForPhase('night');
         scheduleNightWave();
@@ -166,12 +178,37 @@ export default function createDayNightSystem(scene) {
 
     function scheduleNightWave() {
         const nightCfg = WORLD_GEN.spawns.zombie.nightWaves;
-        scene.nightWaveTimer = scene.time.addEvent({
-            delay: 10,
-            loop: false,
-            callback: () => {
-                scene.waveNumber++;
+        const nightDuration = WORLD_GEN.dayNight.nightMs;
+        const segmentDuration = nightDuration / SEGMENT_COUNT;
+
+        for (let segmentIndex = 0; segmentIndex < SEGMENT_COUNT; segmentIndex++) {
+            const segmentStart = segmentIndex * segmentDuration;
+            const segmentEnd = segmentStart + segmentDuration;
+            const minDelay = segmentStart + segmentDuration * 0.25;
+            const maxDelay = segmentEnd - nightCfg.burstIntervalMs;
+            const hasValidRange = minDelay <= maxDelay;
+            const fallbackDelay = Phaser.Math.Clamp(
+                Math.floor(segmentStart + segmentDuration * 0.5),
+                segmentStart,
+                segmentEnd,
+            );
+            const delay = hasValidRange
+                ? Phaser.Math.Between(minDelay, maxDelay)
+                : fallbackDelay;
+
+            let timer;
+            const removeTimer = () => {
+                const index = nightWaveTimers.indexOf(timer);
+                if (index !== -1) {
+                    nightWaveTimers.splice(index, 1);
+                }
+            };
+
+            timer = scene.time.delayedCall(delay, () => {
+                removeTimer();
                 if (scene.phase !== 'night' || scene.isGameOver) return;
+
+                scene.waveNumber++;
 
                 const dayBonus = scene.dayIndex * nightCfg.perDay;
                 const targetCount = Math.min(
@@ -194,13 +231,10 @@ export default function createDayNightSystem(scene) {
                         }
                     });
                 }
+            });
 
-                scene.time.delayedCall(nightCfg.waveIntervalMs, () => {
-                    if (scene.phase === 'night' && !scene.isGameOver)
-                        scheduleNightWave();
-                });
-            },
-        });
+            nightWaveTimers.push(timer);
+        }
     }
 
     // ----- Phase Info -----

--- a/test/systems/dayNightSystem.test.js
+++ b/test/systems/dayNightSystem.test.js
@@ -3,19 +3,40 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import createDayNightSystem from '../../systems/world_gen/dayNightSystem.js';
 import DevTools from '../../systems/DevTools.js';
+import { WORLD_GEN } from '../../systems/world_gen/worldGenConfig.js';
 
 globalThis.Phaser = {
     Math: {
         Linear: (start, end, t) => start + (end - start) * t,
         Clamp: (v, min, max) => Math.min(Math.max(v, min), max),
+        Between: (min, max) => Math.floor((min + max) / 2),
+    },
+    Scenes: {
+        Events: {
+            SHUTDOWN: 'shutdown',
+        },
     },
 };
 
+function createEventStub() {
+    let handler = null;
+    return {
+        once(eventName, cb) {
+            handler = cb;
+        },
+        emitShutdown() {
+            if (handler) handler();
+        },
+    };
+}
+
 test('tick scales day-night progression with time scale', () => {
+    const events = createEventStub();
     const scene = {
         phase: 'day',
         dayIndex: 1,
         nightOverlay: { setAlpha() {} },
+        events,
     };
     const system = createDayNightSystem(scene);
 
@@ -28,5 +49,57 @@ test('tick scales day-night progression with time scale', () => {
     assert.equal(scene._phaseElapsedMs, 300);
 
     DevTools.cheats.timeScale = 1;
+    events.emitShutdown();
+});
+
+test('scheduleNightWave queues timers within each night segment', () => {
+    const events = createEventStub();
+    const scheduledDelays = [];
+    const scene = {
+        phase: 'night',
+        dayIndex: 1,
+        waveNumber: 0,
+        isGameOver: false,
+        time: {
+            delayedCall(delay) {
+                scheduledDelays.push(delay);
+                return {
+                    remove() {},
+                };
+            },
+        },
+        combat: {
+            getEligibleZombieTypesForPhase() {
+                return ['basic'];
+            },
+            pickZombieTypeWeighted() {
+                return 'basic';
+            },
+            spawnZombie() {},
+        },
+        events,
+    };
+
+    const system = createDayNightSystem(scene);
+    system.scheduleNightWave();
+
+    const segmentCount = Math.max(
+        WORLD_GEN.dayNight.segments?.perPhase ?? 3,
+        1,
+    );
+    assert.equal(scheduledDelays.length, segmentCount);
+
+    const nightDuration = WORLD_GEN.dayNight.nightMs;
+    const segmentDuration = nightDuration / segmentCount;
+
+    for (let i = 0; i < scheduledDelays.length; i++) {
+        const segmentStart = i * segmentDuration;
+        const segmentEnd = segmentStart + segmentDuration;
+        const delay = scheduledDelays[i];
+        assert.ok(delay >= segmentStart, 'delay should be in segment start');
+        assert.ok(delay <= segmentEnd, 'delay should be in segment end');
+    }
+
+    events.emitShutdown();
 });
 


### PR DESCRIPTION
Summary:
- Guard against leftover night wave timers when swapping between day and night so retired callbacks cannot spawn extra zombies.
- Evenly schedule night wave bursts across the configured night segments for predictable pacing.
- Add unit coverage to pin the new timer windows and retain timer cleanup on shutdown.

Technical Approach:
- systems/world_gen/dayNightSystem.js: manage a module-scoped nightWaveTimers array with clearNightWaveTimers(), clear timers on phase swaps, stagger night wave delayed calls per segment, and remove timers on scene shutdown.
- scenes/MainScene.js: drop the unused nightWaveTimer property now that timers are internal to the system.
- test/systems/dayNightSystem.test.js: stub Phaser.Scenes.Events, exercise scheduleNightWave(), and assert delays fall into each night segment.

Performance:
- Reuse Phaser timers instead of allocating per-frame work, and clear them on shutdown to avoid leaks; no new allocations introduced in update() paths.

Risks & Rollback:
- Misconfigured timer windows could reduce night spawn frequency; revert systems/world_gen/dayNightSystem.js and related test updates to restore the prior single-timer behaviour.

QA Steps:
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cde0af52388322b9a3a0d777e79f34