### PR TITLE
feat: add pooled lighting helpers

### DIFF
--- a/systems/pools/zombiePool.js
+++ b/systems/pools/zombiePool.js
@@ -13,11 +13,17 @@ export default function createZombiePool(scene) {
                 .setActive(true)
                 .setVisible(true);
             zombie.body && (zombie.body.enable = true);
+            if (typeof scene.applyLightPipeline === 'function') {
+                scene.applyLightPipeline(zombie);
+            }
             return zombie;
         }
         const z = scene.zombies.create(0, 0, texKey);
         if (!z.body) scene.physics.add.existing(z);
         z.body.setAllowGravity(false);
+        if (typeof scene.applyLightPipeline === 'function') {
+            scene.applyLightPipeline(z);
+        }
         return z;
     }
 

--- a/systems/resourceSystem.js
+++ b/systems/resourceSystem.js
@@ -927,6 +927,15 @@ function createResourceSystem(scene) {
             if (!trunk) return;
             const needsPhysics = !!ctx.needsPhysics;
 
+            if (def?.world?.light) {
+                if (typeof scene.applyLightPipeline === 'function') {
+                    scene.applyLightPipeline(trunk);
+                }
+                if (typeof scene.attachLightToObject === 'function') {
+                    scene.attachLightToObject(trunk, def.world.light);
+                }
+            }
+
             if (def.collectible) {
                 trunk.setInteractive();
                 trunk.on('pointerdown', (pointer) => {
@@ -1087,6 +1096,13 @@ function createResourceSystem(scene) {
             .setScale(def.world?.scale ?? 1);
         scene.physics.add.existing(obj);
         obj.body.setAllowGravity(false);
+
+        if (typeof scene.applyLightPipeline === 'function' && def.world?.light) {
+            scene.applyLightPipeline(obj);
+        }
+        if (def.world?.light && typeof scene.attachLightToObject === 'function') {
+            scene.attachLightToObject(obj, def.world.light);
+        }
     }
 
     // Expose API on the scene and return it for convenience


### PR DESCRIPTION
Summary:
- Enable the Light2D system in MainScene with a pooled player light and teardown hooks.
- Expose lighting helper methods for attaching pooled lights and apply them to dropped items, zombies, and light-emitting resources.
- Darken the midnight segment by forcing the overlay and ambient color while ensuring timers are cleaned on shutdown.

Technical Approach:
- scenes/MainScene.js: enable lights, add helper APIs for pooling/attaching lights, update teardown, and integrate with dropped items.
- systems/resourceSystem.js & systems/pools/zombiePool.js: call the new helpers when spawning resources, world items, and zombies.
- systems/world_gen/dayNightSystem.js: clamp midnight lighting and clear timers on shutdown/destroy events.

Performance:
- Lights are pooled and reused via arrays, and update() reuses bindings without allocations.
- Only position math runs during update() for attached lights; no per-frame object creation.

Risks & Rollback:
- Lighting changes could affect scene visuals if Light2D isn’t supported; rollback by reverting MainScene lighting helpers.
- Midnight overlay adjustments could make the scene too dark; revert the dayNightSystem changes if necessary.

QA Steps:
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cde3ddd63c83228f2b8cdf20ab0045