### PR TITLE
Add coverage for day/night segment thresholds

### DIFF
--- a/test/systems/dayNightSystem.test.js
+++ b/test/systems/dayNightSystem.test.js
@@ -1,7 +1,10 @@
 // test/systems/dayNightSystem.test.js — verifies day/night timing
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import createDayNightSystem from '../../systems/world_gen/dayNightSystem.js';
+import createDayNightSystem, {
+    DAY_SEGMENTS,
+    NIGHT_SEGMENTS,
+} from '../../systems/world_gen/dayNightSystem.js';
 import DevTools from '../../systems/DevTools.js';
 import { WORLD_GEN } from '../../systems/world_gen/worldGenConfig.js';
 
@@ -14,18 +17,29 @@ globalThis.Phaser = {
     Scenes: {
         Events: {
             SHUTDOWN: 'shutdown',
+            DESTROY: 'destroy',
         },
     },
 };
 
 function createEventStub() {
-    let handler = null;
+    const handlers = Object.create(null);
     return {
         once(eventName, cb) {
-            handler = cb;
+            handlers[eventName] = cb;
+        },
+        emit(eventName) {
+            const handler = handlers[eventName];
+            if (typeof handler === 'function') {
+                delete handlers[eventName];
+                handler();
+            }
         },
         emitShutdown() {
-            if (handler) handler();
+            this.emit(Phaser.Scenes.Events.SHUTDOWN);
+        },
+        emitDestroy() {
+            this.emit(Phaser.Scenes.Events.DESTROY);
         },
     };
 }
@@ -55,6 +69,7 @@ test('tick scales day-night progression with time scale', () => {
 test('scheduleNightWave queues timers within each night segment', () => {
     const events = createEventStub();
     const scheduledDelays = [];
+    const reusableTimer = { remove() {} };
     const scene = {
         phase: 'night',
         dayIndex: 1,
@@ -63,9 +78,7 @@ test('scheduleNightWave queues timers within each night segment', () => {
         time: {
             delayedCall(delay) {
                 scheduledDelays.push(delay);
-                return {
-                    remove() {},
-                };
+                return reusableTimer;
             },
         },
         combat: {
@@ -99,6 +112,183 @@ test('scheduleNightWave queues timers within each night segment', () => {
         assert.ok(delay >= segmentStart, 'delay should be in segment start');
         assert.ok(delay <= segmentEnd, 'delay should be in segment end');
     }
+
+    events.emitShutdown();
+});
+
+test('phase segments update at expected elapsed thresholds and midnight forces full darkness', () => {
+    const events = createEventStub();
+    const overlayStub = {
+        lastAlpha: null,
+        setAlpha(value) {
+            this.lastAlpha = value;
+        },
+    };
+    const lightsStub = {
+        lastColor: null,
+        setAmbientColor(value) {
+            this.lastColor = value;
+        },
+    };
+    const reusableTimer = { remove() {} };
+    const scene = {
+        phase: 'day',
+        dayIndex: 3,
+        nightOverlay: overlayStub,
+        lights: lightsStub,
+        _baseAmbientColor: 0x101010,
+        events,
+        time: {
+            delayedCall() {
+                return reusableTimer;
+            },
+            addEvent() {
+                return reusableTimer;
+            },
+        },
+    };
+
+    const system = createDayNightSystem(scene);
+    DevTools.cheats.timeScale = 1;
+
+    const { dayNight } = WORLD_GEN;
+    const segmentCount = Math.max(dayNight.segments?.perPhase ?? 3, 1);
+    const daySegmentDuration = dayNight.dayMs / segmentCount;
+    const nightSegmentDuration = dayNight.nightMs / segmentCount;
+
+    const defaultDayLabel = DAY_SEGMENTS[0] || 'Daytime';
+    const defaultNightLabel = NIGHT_SEGMENTS[0] || 'Dusk';
+    const maxDayIndex = Math.max(0, Math.min(DAY_SEGMENTS.length - 1, segmentCount - 1));
+    const maxNightIndex = Math.max(0, Math.min(NIGHT_SEGMENTS.length - 1, segmentCount - 1));
+
+    function resolveLabel(labels, fallback, index, maxIndex) {
+        const clampedIndex = Math.min(index, maxIndex);
+        const label = labels[clampedIndex];
+        return typeof label === 'string' && label.length > 0 ? label : fallback;
+    }
+
+    function assertSegmentState(expectedIndex, expectedLabel, context) {
+        assert.equal(
+            scene.phaseSegmentIndex,
+            expectedIndex,
+            `${context} index should match expected segment`,
+        );
+        assert.equal(
+            scene.phaseSegmentLabel,
+            expectedLabel,
+            `${context} label should match expected text`,
+        );
+    }
+
+    // ----- Day progression -----
+    scene.phase = 'day';
+    scene._phaseElapsedMs = 0;
+    system.tick(0);
+    assertSegmentState(0, defaultDayLabel, 'day start');
+
+    let currentElapsed = 0;
+    for (let boundaryIndex = 0; boundaryIndex < segmentCount - 1; boundaryIndex++) {
+        const boundary = Math.ceil(daySegmentDuration * (boundaryIndex + 1));
+        const beforeBoundary = Math.max(0, boundary - 1);
+        if (beforeBoundary > currentElapsed) {
+            system.tick(beforeBoundary - currentElapsed);
+            currentElapsed = beforeBoundary;
+        }
+
+        const holdIndex = Math.min(boundaryIndex, maxDayIndex);
+        const holdLabel = resolveLabel(
+            DAY_SEGMENTS,
+            defaultDayLabel,
+            boundaryIndex,
+            maxDayIndex,
+        );
+        assertSegmentState(
+            holdIndex,
+            holdLabel,
+            `day segment ${boundaryIndex} before next boundary`,
+        );
+
+        if (boundary > currentElapsed) {
+            system.tick(boundary - currentElapsed);
+            currentElapsed = boundary;
+        }
+
+        const nextIndex = Math.min(boundaryIndex + 1, maxDayIndex);
+        const nextLabel = resolveLabel(
+            DAY_SEGMENTS,
+            defaultDayLabel,
+            boundaryIndex + 1,
+            maxDayIndex,
+        );
+        assertSegmentState(
+            nextIndex,
+            nextLabel,
+            `day segment ${boundaryIndex + 1} after crossing boundary`,
+        );
+    }
+
+    // ----- Night progression -----
+    scene.phase = 'night';
+    scene._phaseElapsedMs = 0;
+    overlayStub.lastAlpha = null;
+    system.tick(0);
+    assertSegmentState(0, defaultNightLabel, 'night start');
+
+    currentElapsed = 0;
+    let midnightVerified = false;
+    for (let boundaryIndex = 0; boundaryIndex < segmentCount - 1; boundaryIndex++) {
+        const boundary = Math.ceil(nightSegmentDuration * (boundaryIndex + 1));
+        const beforeBoundary = Math.max(0, boundary - 1);
+        if (beforeBoundary > currentElapsed) {
+            system.tick(beforeBoundary - currentElapsed);
+            currentElapsed = beforeBoundary;
+        }
+
+        const holdIndex = Math.min(boundaryIndex, maxNightIndex);
+        const holdLabel = resolveLabel(
+            NIGHT_SEGMENTS,
+            defaultNightLabel,
+            boundaryIndex,
+            maxNightIndex,
+        );
+        assertSegmentState(
+            holdIndex,
+            holdLabel,
+            `night segment ${boundaryIndex} before next boundary`,
+        );
+
+        if (boundary > currentElapsed) {
+            system.tick(boundary - currentElapsed);
+            currentElapsed = boundary;
+        }
+
+        const nextIndex = Math.min(boundaryIndex + 1, maxNightIndex);
+        const nextLabel = resolveLabel(
+            NIGHT_SEGMENTS,
+            defaultNightLabel,
+            boundaryIndex + 1,
+            maxNightIndex,
+        );
+        assertSegmentState(
+            nextIndex,
+            nextLabel,
+            `night segment ${boundaryIndex + 1} after crossing boundary`,
+        );
+
+        if (!midnightVerified && typeof nextLabel === 'string') {
+            const normalized = nextLabel.trim().toLowerCase();
+            if (normalized === 'midnight') {
+                assert.equal(
+                    overlayStub.lastAlpha,
+                    1,
+                    'night overlay alpha should be forced to 1 during midnight segment',
+                );
+                midnightVerified = true;
+            }
+        }
+    }
+
+    assert.ok(midnightVerified, 'midnight segment should have been observed during test');
 
     events.emitShutdown();
 });


### PR DESCRIPTION
Summary:
- Add regression coverage ensuring day and night segments advance labels at configured elapsed-time boundaries.
- Verify the midnight segment forces a fully opaque overlay and reuse timer mocks in tests to avoid extra allocations.

Technical Approach:
- Updated `test/systems/dayNightSystem.test.js` to import segment label exports, extend the Phaser event stub, reuse timer mocks, and add an elapsed-time progression test covering both phases and the midnight overlay behaviour.

Performance:
- Test doubles reuse shared timer stubs so no new per-iteration allocations are introduced; runtime code is untouched.

Risks & Rollback:
- Low risk and limited to automated tests. Revert this commit to roll back.

QA Steps:
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cde790b7e483229d4fd048c79a101b