### PR TITLE
fix(dayNight): freeze cycle when time scale is zero

### DIFF
--- a/systems/world_gen/dayNightSystem.js
+++ b/systems/world_gen/dayNightSystem.js
@@ -351,9 +351,12 @@ export default function createDayNightSystem(scene) {
 
     // ----- Tick -----
     function tick(delta) {
-        const scale = DevTools.cheats.timeScale || 1;
+        const cheatScaleRaw = DevTools?.cheats?.timeScale;
+        let cheatScale =
+            typeof cheatScaleRaw === 'number' ? cheatScaleRaw : 1;
+        if (cheatScale < 0) cheatScale = 0;
         scene._phaseElapsedMs =
-            (scene._phaseElapsedMs || 0) + ((delta * scale) | 0);
+            (scene._phaseElapsedMs || 0) + ((delta * cheatScale) | 0);
         let phaseElapsed = getPhaseElapsed();
         let phaseDuration = getPhaseDuration();
         if (phaseElapsed >= phaseDuration) {


### PR DESCRIPTION
Summary:
- Stop advancing the day/night phase timer while the DevTools time scale is zero so wave and trickle timers resume correctly after unpausing.

Technical Approach:
- Clamp the cheat time scale in `systems/world_gen/dayNightSystem.js` so the accumulated phase time respects values at or below zero.

Performance:
- Only updates arithmetic on the cached phase timer; no new allocations or per-frame math beyond an extra clamp.

Risks & Rollback:
- Low risk; revert this commit if any timing regressions appear in the day/night cycle or spawning.

QA Steps:
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cded2d45ec8322b495e5a57cc985be