### PR TITLE
fix: refresh player night glow updates

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -1256,6 +1256,7 @@ export default class MainScene extends Phaser.Scene {
 
     _updatePlayerLightGlow() {
         const light = this.playerLight;
+        if (!light) return;
 
         let normalized = this._playerLightCachedNormalizedSegment;
         const rawLabel = this.phaseSegmentLabel;
@@ -1280,19 +1281,27 @@ export default class MainScene extends Phaser.Scene {
             this._playerLightNightActive = shouldGlow;
         }
 
-        if (!light || !stateChanged) return;
+        if (!shouldGlow) {
+            if (stateChanged || light.intensity !== 0) {
+                light.intensity = 0;
+            }
+            if (stateChanged && light.active) {
+                light.active = false;
+            }
+            return;
+        }
 
-        if (shouldGlow) {
-            const radius =
-                this.lightSettings?.player?.nightRadius ?? this._playerLightNightRadius;
-            const maskScale = this.lightSettings?.player?.maskScale ?? 1;
-            light.radius = radius;
-            light.maskScale = maskScale;
-            light.intensity = 1;
-            light.active = radius > 0;
-        } else {
-            light.intensity = 0;
-            light.active = false;
+        const radius =
+            this.lightSettings?.player?.nightRadius ?? this._playerLightNightRadius;
+        const maskScale = this.lightSettings?.player?.maskScale ?? 1;
+        const hasRadius = radius > 0;
+
+        light.radius = radius;
+        light.maskScale = maskScale;
+        light.intensity = hasRadius ? 1 : 0;
+
+        if (stateChanged || light.active !== hasRadius) {
+            light.active = hasRadius;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the player night glow continually re-reads radius, mask scale, and intensity from `lightSettings`
- keep enable/disable transitions tied to night segment changes while syncing the light's active flag with zero-radius cases

## Technical Approach
- scenes/MainScene.js: refactor `_updatePlayerLightGlow` to early exit when no light, recompute cached segment data, and always assign the current radius, mask scale, intensity, and active flag based on the latest settings

## Performance
- avoids per-frame allocations by reusing cached strings/booleans and only touching primitive properties on the existing light instance

## Risks & Rollback
- low risk: scoped to player glow handling; revert by restoring `scenes/MainScene.js` to the previous revision if regressions appear

## QA Steps
- run `npm test`
- (in play mode) adjust `lightSettings.player.nightRadius` via DevTools and confirm the night overlay hole updates immediately without flicker or allocations


------
https://chatgpt.com/codex/tasks/task_e_68cf1af4e8888322b081ba368bf13199