### PR TITLE
fix: calibrate night mask inner bubble

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -1575,16 +1575,20 @@ export default class MainScene extends Phaser.Scene {
             const normalized = tileCount <= 1 ? 0 : ring / (tileCount - 1);
             const falloff = Phaser.Math.Easing.Quadratic.Out(1 - normalized);
             const alpha = Phaser.Math.Clamp(0.05 + falloff * 0.95, 0, 1);
-            const radiusNormalized =
-                baseRadius > 0
-                    ? Phaser.Math.Clamp(
-                          (ring <= 0
-                              ? tileSize * 0.35
-                              : tileSize * (ring + 0.5)) / baseRadius,
-                          0,
-                          1,
-                      )
-                    : 0;
+            const minInnerRadiusNormalized = 0.35;
+            let radiusNormalized;
+            if (tileCount <= 1) {
+                radiusNormalized = 1;
+            } else {
+                radiusNormalized =
+                    minInnerRadiusNormalized +
+                    (1 - minInnerRadiusNormalized) * normalized;
+                radiusNormalized = Phaser.Math.Clamp(
+                    radiusNormalized,
+                    minInnerRadiusNormalized,
+                    1,
+                );
+            }
 
             layers[ring] = {
                 alpha: Phaser.Math.Clamp(alpha, 0, 1),

--- a/test/scenes/mainScene.lightMaskGradient.test.js
+++ b/test/scenes/mainScene.lightMaskGradient.test.js
@@ -1,0 +1,63 @@
+// test/scenes/mainScene.lightMaskGradient.test.js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function quadraticOut(t) {
+    return t * (2 - t);
+}
+
+test('player light mask gradient reserves a large inner bubble', async () => {
+    const previousPhaser = globalThis.Phaser;
+    globalThis.Phaser = {
+        Scene: class SceneStub {
+            constructor() {
+                this.sys = { events: { once() {}, on() {}, off() {} } };
+                this.events = this.sys.events;
+            }
+        },
+        Math: {
+            PI2: Math.PI * 2,
+            Clamp: clamp,
+            Linear: (start, end, t) => start + (end - start) * t,
+            Easing: {
+                Quadratic: {
+                    Out: quadraticOut,
+                },
+            },
+        },
+    };
+
+    try {
+        const { default: MainScene } = await import('../../scenes/MainScene.js');
+        const scene = new MainScene();
+
+        const gradient = scene._buildLightMaskGradient(16, 5);
+        assert.equal(gradient.layers.length, 5);
+
+        const innerLayer = gradient.layers[0];
+        assert.ok(innerLayer.radiusNormalized >= 0.34);
+        assert.ok(innerLayer.radiusNormalized <= 0.36);
+
+        const outerLayer = gradient.layers[gradient.layers.length - 1];
+        assert.equal(outerLayer.radiusNormalized, 1);
+
+        const midLayer = gradient.layers[2];
+        assert.ok(midLayer.radiusNormalized > innerLayer.radiusNormalized);
+        assert.ok(midLayer.radiusNormalized < outerLayer.radiusNormalized);
+        assert.ok(Math.abs(midLayer.radiusNormalized - 0.675) <= 0.01);
+
+        for (let i = 1; i < gradient.layers.length; i++) {
+            assert.ok(
+                gradient.layers[i].radiusNormalized >=
+                    gradient.layers[i - 1].radiusNormalized,
+            );
+        }
+    } finally {
+        globalThis.Phaser = previousPhaser;
+    }
+});
+


### PR DESCRIPTION
Summary:
- Tie the player night mask ring radii to their indices so the inner bubble stays roughly 35% of the light radius while keeping the eased fade and full outer edge.
- Add a unit test that locks the expected light mask gradient so future tweaks keep the daylight bubble obvious.

Technical Approach:
- Updated `_buildLightMaskGradient` in `scenes/MainScene.js` to derive `radiusNormalized` from the ring index and clamp the inner ring to ~0.35 of the final radius.
- Added `test/scenes/mainScene.lightMaskGradient.test.js` to exercise the gradient builder with a Phaser stub and assert the radius distribution.

Performance:
- The gradient still relies on simple arithmetic with no new allocations in `update()` or per-frame work.

Risks & Rollback:
- Visual tuning changes could still need adjustment for different tile counts; revert the commit if the light bubble feels too wide or narrow.

QA Steps:
- npm test
- Run the game, transition to night, and confirm the survivor stands in a clearly visible daylight bubble with the eased fade/flicker intact.


------
https://chatgpt.com/codex/tasks/task_e_68d073e510d083228b902aaef1ab97b6