### PR TITLE
fix: align night mask ring distribution

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -1576,19 +1576,13 @@ export default class MainScene extends Phaser.Scene {
             const falloff = Phaser.Math.Easing.Quadratic.Out(1 - normalized);
             const alpha = Phaser.Math.Clamp(0.05 + falloff * 0.95, 0, 1);
             const minInnerRadiusNormalized = 0.35;
-            let radiusNormalized;
-            if (tileCount <= 1) {
-                radiusNormalized = 1;
-            } else {
-                radiusNormalized =
-                    minInnerRadiusNormalized +
-                    (1 - minInnerRadiusNormalized) * normalized;
-                radiusNormalized = Phaser.Math.Clamp(
-                    radiusNormalized,
-                    minInnerRadiusNormalized,
-                    1,
-                );
-            }
+            const ringRadiusNormalized =
+                tileCount <= 1 ? 1 : (ring + 1) / tileCount;
+            const radiusNormalized = Phaser.Math.Clamp(
+                ringRadiusNormalized,
+                minInnerRadiusNormalized,
+                1,
+            );
 
             layers[ring] = {
                 alpha: Phaser.Math.Clamp(alpha, 0, 1),

--- a/test/scenes/mainScene.lightMaskGradient.test.js
+++ b/test/scenes/mainScene.lightMaskGradient.test.js
@@ -45,16 +45,30 @@ test('player light mask gradient reserves a large inner bubble', async () => {
         const outerLayer = gradient.layers[gradient.layers.length - 1];
         assert.equal(outerLayer.radiusNormalized, 1);
 
-        const midLayer = gradient.layers[2];
+        const midLayerIndex = 2;
+        const midLayer = gradient.layers[midLayerIndex];
         assert.ok(midLayer.radiusNormalized > innerLayer.radiusNormalized);
         assert.ok(midLayer.radiusNormalized < outerLayer.radiusNormalized);
-        assert.ok(Math.abs(midLayer.radiusNormalized - 0.675) <= 0.01);
+        const expectedMidRadius = Math.max(
+            0.35,
+            (midLayerIndex + 1) / gradient.layers.length,
+        );
+        assert.ok(Math.abs(midLayer.radiusNormalized - expectedMidRadius) <= 0.01);
 
         for (let i = 1; i < gradient.layers.length; i++) {
             assert.ok(
                 gradient.layers[i].radiusNormalized >=
                     gradient.layers[i - 1].radiusNormalized,
             );
+        }
+
+        for (let ring = 0; ring < gradient.layers.length; ring++) {
+            const layer = gradient.layers[ring];
+            const expectedRadius = Math.max(
+                0.35,
+                (ring + 1) / gradient.layers.length,
+            );
+            assert.ok(Math.abs(layer.radiusNormalized - expectedRadius) <= 0.000001);
         }
     } finally {
         globalThis.Phaser = previousPhaser;


### PR DESCRIPTION
Summary:
- derive cached night-overlay ring radii from the ring indices so the player bubble keeps ~35% of the final light radius.
- update the light mask gradient test expectations to cover the ring-driven radius distribution.

Technical Approach:
- scenes/MainScene.js::_buildLightMaskGradient clamps each ring radius using (ring + 1) / tileCount.
- test/scenes/mainScene.lightMaskGradient.test.js asserts the new distribution for inner, middle, and outer rings.

Performance:
- No new per-frame work; still reuse cached gradient data when drawing the night overlay.

Risks & Rollback:
- Slightly altered falloff might feel too sharp; revert this commit to restore the previous distribution.

QA Steps:
- Launch the game and observe dusk, midnight, and dawn to confirm the daylight bubble around the player is obvious.
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d0781a86548322a2115eb157d74a2f