### PR TITLE
Fix player light bubble during dusk fade

### DIFF
--- a/scenes/MainScene.js
+++ b/scenes/MainScene.js
@@ -1351,11 +1351,20 @@ export default class MainScene extends Phaser.Scene {
             this._playerLightCachedNormalizedSegment = normalized;
         }
 
-        const shouldGlow =
-            this.phase === 'night' &&
-            (normalized === 'dusk' ||
-                normalized === 'midnight' ||
-                normalized === 'dawn');
+        const overlayAlpha = this.nightOverlay?.alpha ?? 0;
+        const overlayDarkEnough = overlayAlpha > 0.001;
+
+        let shouldGlow = false;
+        if (overlayDarkEnough) {
+            if (this.phase === 'night') {
+                shouldGlow =
+                    normalized === 'dusk' ||
+                    normalized === 'midnight' ||
+                    normalized === 'dawn';
+            } else {
+                shouldGlow = true;
+            }
+        }
 
         const settings = this.lightSettings?.player;
         const rawRadius = settings?.nightRadius;


### PR DESCRIPTION
Summary:
- make the player light bubble kick in whenever the night overlay darkens so dusk fades still leave a visibility hole.

Technical Approach:
- updated MainScene._updatePlayerLightGlow to check the overlay alpha before gating the light on phase labels.

Performance:
- only adds scalar comparisons inside the existing update path; no new allocations or per-frame objects.

Risks & Rollback:
- if the dusk light bubble is undesirable, revert commit 630ec21 to restore the prior behaviour.

QA Steps:
- let the day-night cycle reach dusk and confirm the player keeps a circular gap in the darkness while the overlay fades in.


------
https://chatgpt.com/codex/tasks/task_e_68d0864ea2b08322b90b880fce9cf25b